### PR TITLE
docs: regenerate eslint-doc-generator table

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,14 +73,16 @@ module.exports = {
 <!-- prettier-ignore-start -->
 <!-- begin auto-generated rules list -->
 
+💼 Configurations enabled in.\
+✅ Set in the `recommended` configuration.\
 🔧 Automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/user-guide/command-line-interface#--fix).
 
-| Name                                                           | Description                                                                             | 🔧 |
-| :------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :- |
-| [order-properties](docs/rules/order-properties.md)             | Package properties must be declared in standard order                                   | 🔧 |
-| [sort-collections](docs/rules/sort-collections.md)             | Dependencies, scripts, and configuration values must be declared in alphabetical order. | 🔧 |
-| [valid-local-dependency](docs/rules/valid-local-dependency.md) | Checks existence of local dependencies in the package.json                              |    |
-| [valid-package-def](docs/rules/valid-package-def.md)           | Enforce that package.json has all properties required by NPM spec                       |    |
+| Name                                                           | Description                                                                             | 💼 | 🔧 |
+| :------------------------------------------------------------- | :-------------------------------------------------------------------------------------- | :- | :- |
+| [order-properties](docs/rules/order-properties.md)             | Package properties must be declared in standard order                                   | ✅  | 🔧 |
+| [sort-collections](docs/rules/sort-collections.md)             | Dependencies, scripts, and configuration values must be declared in alphabetical order. | ✅  | 🔧 |
+| [valid-local-dependency](docs/rules/valid-local-dependency.md) | Checks existence of local dependencies in the package.json                              | ✅  |    |
+| [valid-package-def](docs/rules/valid-package-def.md)           | Enforce that package.json has all properties required by NPM spec                       | ✅  |    |
 
 <!-- end auto-generated rules list -->
 <!-- prettier-ignore-end -->

--- a/docs/rules/order-properties.md
+++ b/docs/rules/order-properties.md
@@ -1,5 +1,7 @@
 # Package properties must be declared in standard order (`package-json/order-properties`)
 
+💼 This rule is enabled in the ✅ `recommended` config.
+
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->

--- a/docs/rules/sort-collections.md
+++ b/docs/rules/sort-collections.md
@@ -1,5 +1,7 @@
 # Dependencies, scripts, and configuration values must be declared in alphabetical order (`package-json/sort-collections`)
 
+💼 This rule is enabled in the ✅ `recommended` config.
+
 🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
 
 <!-- end auto-generated rule header -->

--- a/docs/rules/valid-local-dependency.md
+++ b/docs/rules/valid-local-dependency.md
@@ -1,5 +1,7 @@
 # Checks existence of local dependencies in the package.json (`package-json/valid-local-dependency`)
 
+💼 This rule is enabled in the ✅ `recommended` config.
+
 <!-- end auto-generated rule header -->
 
 ## Rule Details

--- a/docs/rules/valid-package-def.md
+++ b/docs/rules/valid-package-def.md
@@ -1,5 +1,7 @@
 # Enforce that package.json has all properties required by NPM spec (`package-json/valid-package-def`)
 
+💼 This rule is enabled in the ✅ `recommended` config.
+
 <!-- end auto-generated rule header -->
 
 NPM issues warnings after install if the `package.json` has a missing or


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #110
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Regenerates the table following #103.

```shell
pnpm run update:eslint-docs                                                                            
```