### PR TITLE
docs: touchups

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,9 @@
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 <!-- prettier-ignore-end -->
 </a>
-	<a href="https://codecov.io/gh/JoshuaKGoldberg/eslint-plugin-package-json" target="_blank">
-		<img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/eslint-plugin-package-json/branch/main/graph/badge.svg"/>
-	</a>
-	<a href="https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank">
-		<img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" />
-	</a>
-	<a href="https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/LICENSE.md" target="_blank">
-		<img alt="License: MIT" src="https://img.shields.io/github/license/JoshuaKGoldberg/eslint-plugin-package-json?color=21bb42">
-	</a>
+	<a href="https://codecov.io/gh/JoshuaKGoldberg/eslint-plugin-package-json" target="_blank"><img alt="Codecov Test Coverage" src="https://codecov.io/gh/JoshuaKGoldberg/eslint-plugin-package-json/branch/main/graph/badge.svg"/></a>
+	<a href="https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CODE_OF_CONDUCT.md" target="_blank"><img alt="Contributor Covenant" src="https://img.shields.io/badge/code_of_conduct-enforced-21bb42" /></a>
+	<a href="https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/LICENSE.md" target="_blank"><img alt="License: MIT" src="https://img.shields.io/github/license/JoshuaKGoldberg/eslint-plugin-package-json?color=21bb42"></a>
 	<img alt="Style: Prettier" src="https://img.shields.io/badge/style-prettier-21bb42.svg" />
 	<img alt="TypeScript: Strict" src="https://img.shields.io/badge/typescript-strict-21bb42.svg" />
 	<img alt="npm package version" src="https://img.shields.io/npm/v/eslint-plugin-package-json?color=21bb42" />
@@ -26,17 +20,15 @@
 
 ## Installation
 
-You'll first need to install [ESLint](http://eslint.org) >=8 and `eslint-plugin-package-json`:
+This package requires [ESLint](http://eslint.org) 8 and [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser):
 
 ```shell
 npm install eslint eslint-plugin-package-json jsonc-eslint-parser --save-dev
 ```
 
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `eslint-plugin-package-json` globally.
-
 ## Usage
 
-Add an override to your ESLint configuration file that specifies this plugin, [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser) and its recommended rules for your `package.json` file:
+Add an override to your ESLint configuration file that specifies this plugin, [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser), and its recommended rules for your `package.json` file:
 
 ```js
 module.exports = {
@@ -51,12 +43,14 @@ module.exports = {
 };
 ```
 
-Or, individually configure the rules you want to use under the rules section.
+You may also want to individually configure rules.
+See [ESLint's _Configure Rules_ guide](https://eslint.org/docs/latest/use/configure/rules) for details on how to customize your rules.
 
 ```js
 module.exports = {
 	overrides: [
 		{
+			extends: ["plugin:package-json/recommended"],
 			files: ["package.json"],
 			parser: "jsonc-eslint-parser",
 			plugins: ["package-json"],
@@ -83,7 +77,7 @@ module.exports = {
 | [prefer-repository-shorthand](docs/rules/prefer-repository-shorthand.md) | Enforce shorthand declaration for GitHub repository.                                    | ✅  | 🔧 |
 | [sort-collections](docs/rules/sort-collections.md)                       | Dependencies, scripts, and configuration values must be declared in alphabetical order. | ✅  | 🔧 |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)           | Checks existence of local dependencies in the package.json                              | ✅  |    |
-| [valid-package-def](docs/rules/valid-package-def.md)                     | Enforce that package.json has all properties required by NPM spec                       | ✅  |    |
+| [valid-package-def](docs/rules/valid-package-def.md)                     | Enforce that package.json has all properties required by the npm spec                   | ✅  |    |
 
 <!-- end auto-generated rules list -->
 <!-- prettier-ignore-end -->

--- a/docs/rules/order-properties.md
+++ b/docs/rules/order-properties.md
@@ -8,7 +8,8 @@
 
 A conventional order exists for `package.json` top-level properties.
 npm does not enforce this order, but for consistency and readability, this rule can enforce it.
-It is especially useful in monorepos, where many `package.json` files may exist.
+
+> 💡 This rule is especially useful in monorepos with many `package.json` files that would ideally be consistently ordered.
 
 ## Rule Details
 
@@ -16,12 +17,16 @@ This rule detects when properties in `package.json` are out of order.
 
 Examples of **incorrect** code for this rule:
 
+<!-- eslint-disable jsonc/sort-keys -->
+
 ```json
 {
-	"name": "my-package",
-	"version": "1.0.0"
+	"version": "1.0.0",
+	"name": "my-package"
 }
 ```
+
+<!-- eslint-enable jsonc/sort-keys -->
 
 This is an error because "version" should come after "name".
 

--- a/docs/rules/sort-collections.md
+++ b/docs/rules/sort-collections.md
@@ -6,9 +6,14 @@
 
 <!-- end auto-generated rule header -->
 
-Whenever NPM changes package dependencies through `npm install`, it lexically sorts (that is, alphabetizes by package name) all dependencies in `package.json`. Nevertheless, sometimes a developer will manually update `package.json` and leave dependencies out of order, leading to "noise" in changesets when a later change re-sorts the packages. This rule aims to keep the dependency collections sorted in every commit.
+Whenever npm changes package dependencies through `npm install`, it lexically sorts (that is, alphabetizes by package name) all dependencies in `package.json`.
+However, developers will manually update `package.json` and accidentally leave dependencies out of order.
+Doing so leads to "noise" in commits when a later change re-sorts the packages.
 
-The `scripts` collection in `package.json` is not automatically sorted by NPM, but this rule also applies to `scripts` by default, to keep them organized. To keep related scripts close together in the file, consider using the common NPM script convention of colon-separated namespaces, such as `watch:all` or `watch:dist`.
+Furthermore, the `"scripts"` collections in `package.json` files are generally easiest to work with when in alphabetical order.
+To keep related scripts close together in the file, consider using the common npm script convention of colon-separated namespaces, such as `watch:all` or `watch:dist`.
+
+This rule aims to keep the dependency collections sorted in every commit.
 
 ## Rule Details
 

--- a/docs/rules/valid-local-dependency.md
+++ b/docs/rules/valid-local-dependency.md
@@ -6,7 +6,8 @@
 
 ## Rule Details
 
-This rule validates the path for `file:` and `link:` dependencies in a `package.json` file - including name casing. If a `link:` or `file:` path is incorrect yarn does not sub out the link when releasing.
+This rule validates the path for `file:` and `link:` dependencies in a `package.json` file - including name casing.
+If a `link:` or `file:` path is incorrect yarn does not sub out the link when releasing.
 
 Examples of **incorrect** code for this rule (when `../folder` is the correct path):
 

--- a/docs/rules/valid-package-def.md
+++ b/docs/rules/valid-package-def.md
@@ -1,13 +1,11 @@
-# Enforce that package.json has all properties required by NPM spec (`package-json/valid-package-def`)
+# Enforce that package.json has all properties required by the npm spec (`package-json/valid-package-def`)
 
 💼 This rule is enabled in the ✅ `recommended` config.
 
 <!-- end auto-generated rule header -->
 
-NPM issues warnings after install if the `package.json` has a missing or
-invalid required property. This rule uses [`package-json-validator`][pjv] to
-validate all `package.json` files against the [NPM specification][npm-spec],
-and add any violations to lint warnings.
+npm issues warnings after install if the `package.json` has a missing or invalid required property.
+This rule uses [`package-json-validator`][pjv] to validate all `package.json` files against the [npm specification][npm-spec], and add any violations to lint warnings.
 
 ## Rule Details
 
@@ -49,9 +47,8 @@ Examples of **correct** code for this rule:
 
 ## When Not To Use It
 
-NPM may complain, but it works perfectly with many package files that do not
-violate spec. Use this rule only to keep `package.json` files conforming to a
-strict ruleset.
+npm may complain, but it works perfectly with many package files that do not violate spec.
+If you don't mind those complaints then you can disable this rule.
 
 [pjv]: https://github.com/gorillamania/package.json-validator
 [npm-spec]: https://docs.npmjs.com/files/package.json

--- a/src/rules/valid-package-def.ts
+++ b/src/rules/valid-package-def.ts
@@ -4,7 +4,7 @@ import { PJV as PackageValidator } from "package-json-validator";
 import { createRule } from "../createRule.js";
 
 // package-json-validator does not correctly recognize shorthand for repositories and alternate dependency statements, so we discard those values.
-// it also enforces a stricter code for NPM than is really appropriate,
+// it also enforces a stricter code for npm than is really appropriate,
 // so we disable some other errors here.
 const unusedErrorPatterns = [
 	/^Url not valid/i,
@@ -39,7 +39,7 @@ export default createRule({
 		docs: {
 			category: "Best Practices",
 			description:
-				"Enforce that package.json has all properties required by NPM spec",
+				"Enforce that package.json has all properties required by the npm spec",
 			recommended: true,
 		},
 	},


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #112; fixes #113
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Touches up the README.md to better explain itself and no longer reference a global installation.

Also applies a bit of polish to rule docs:
* Applies [sentences-per-line](https://github.com/JoshuaKGoldberg/sentences-per-line) manually
* Lower-cases npm instead of NPM
* General phrasing and such