### PR TITLE
feat: change order-properties order default to sort-package-json

### DIFF
--- a/docs/rules/order-properties.md
+++ b/docs/rules/order-properties.md
@@ -69,39 +69,9 @@ interface {
 }
 ```
 
-Default: `legacy`
+Default: `"sort-package-json"`
 
-```json
-[
-	"name",
-	"version",
-	"private",
-	"publishConfig",
-	"description",
-	"main",
-	"browser",
-	"files",
-	"bin",
-	"directories",
-	"man",
-	"scripts",
-	"repository",
-	"keywords",
-	"author",
-	"license",
-	"bugs",
-	"homepage",
-	"config",
-	"dependencies",
-	"devDependencies",
-	"peerDependencies",
-	"optionalDependencies",
-	"bundledDependencies",
-	"engines",
-	"os",
-	"cpu"
-]
-```
+> ⚠️ The default value for `order` changed from `"legacy"` to `"sort-package-json"` in v0.6.0.
 
 This rule is **autofixable**; run `eslint` with the `--fix` option to sort top-level properties in place.
 Any properties not present in the array of ordered properties will be left in their original positions.

--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -43,7 +43,11 @@ export default createRule<Options>({
 			"Program:exit"() {
 				const { ast, text } = context.sourceCode;
 
-				const options = context.options[0] ?? { order: "legacy" };
+				const options = {
+					order: "sort-package-json",
+					...context.options[0],
+				} satisfies Options[0];
+
 				const requiredOrder =
 					options.order === "legacy"
 						? standardOrderLegacy

--- a/src/tests/rules/order-properties.test.ts
+++ b/src/tests/rules/order-properties.test.ts
@@ -29,13 +29,13 @@ ruleTester.run("order-properties", rule, {
   "name": "invalid-top-level-property-order",
   "version": "1.0.0",
   "description": "npm made me this way",
-  "main": "index.js",
-  "scripts": {
-    "test": "tape"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fake/github.git"
+  },
+  "main": "index.js",
+  "scripts": {
+    "test": "tape"
   }
 }
 `,


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #58
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Applies the change, along with a notice in the docs.

**This is a breaking change**. But since this package is still 0.x, there's nothing necessary to do with semver.