### PR TITLE
fix: correct order-properties key checks

### DIFF
--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -1,3 +1,5 @@
+import type { AST as JsonAST } from "jsonc-eslint-parser";
+
 import sortPackageJson from "sort-package-json";
 
 import { createRule } from "../createRule.js";
@@ -65,7 +67,10 @@ export default createRule<Options>({
 				const { properties } = ast.body[0].expression;
 
 				for (let i = 0; i < properties.length; i += 1) {
-					if (properties[i].value !== orderedKeys[i]) {
+					if (
+						(properties[i].key as JsonAST.JSONStringLiteral)
+							.value !== orderedKeys[i]
+					) {
 						context.report({
 							fix(fixer) {
 								return fixer.replaceText(

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -33,13 +33,6 @@ describe("configs", () => {
 				message: message.message,
 				ruleId: message.ruleId,
 			})),
-		).toEqual([
-			// Our package.json differs from the recommended key order.
-			{
-				message:
-					"Package top-level properties are not ordered in the npm standard way. Run the ESLint auto-fixer to correct.",
-				ruleId: "package-json/order-properties",
-			},
-		]);
+		).toEqual([]);
 	});
 });

--- a/src/tests/rules/order-properties.test.ts
+++ b/src/tests/rules/order-properties.test.ts
@@ -5,18 +5,15 @@ ruleTester.run("order-properties", rule, {
 	invalid: [
 		{
 			code: `{
-	"name": "invalid-top-level-property-order",
-	"scripts": {
-		"test": "tape"
-	},
-	"version": "1.0.0",
-	"description": "npm made me this way",
 	"main": "index.js",
+	"homepage": "https://example.com",
+	"version": "1.0.0",
+	"name": "order-sort-package-json-implicit",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/fake/github.git"
-		}
 	}
+}
 `,
 			errors: [
 				{
@@ -26,72 +23,28 @@ ruleTester.run("order-properties", rule, {
 			],
 			filename: "package.json",
 			output: `{
-  "name": "invalid-top-level-property-order",
+  "name": "order-sort-package-json-implicit",
   "version": "1.0.0",
-  "description": "npm made me this way",
+  "homepage": "https://example.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fake/github.git"
   },
-  "main": "index.js",
-  "scripts": {
-    "test": "tape"
-  }
+  "main": "index.js"
 }
 `,
 		},
 		{
 			code: `{
-	"name": "invalid-top-level-property-order",
-	"scripts": {
-		"test": "tape"
-	},
-	"version": "1.0.0",
-	"description": "npm made me this way",
 	"main": "index.js",
+	"homepage": "https://example.com",
+	"version": "1.0.0",
+	"name": "order-sort-package-json-explicit",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/fake/github.git"
-		}
 	}
-`,
-			errors: [
-				{
-					message:
-						"Package top-level properties are not ordered in the npm standard way. Run the ESLint auto-fixer to correct.",
-				},
-			],
-			filename: "package.json",
-			options: [{ order: "legacy" }],
-			output: `{
-  "name": "invalid-top-level-property-order",
-  "version": "1.0.0",
-  "description": "npm made me this way",
-  "main": "index.js",
-  "scripts": {
-    "test": "tape"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/fake/github.git"
-  }
 }
-`,
-		},
-		{
-			code: `{
-	"name": "invalid-top-level-property-order",
-	"scripts": {
-		"test": "tape"
-	},
-	"version": "1.0.0",
-	"description": "npm made me this way",
-	"main": "index.js",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/fake/github.git"
-		}
-	}
 `,
 			errors: [
 				{
@@ -102,34 +55,60 @@ ruleTester.run("order-properties", rule, {
 			filename: "package.json",
 			options: [{ order: "sort-package-json" }],
 			output: `{
-  "name": "invalid-top-level-property-order",
+  "name": "order-sort-package-json-explicit",
   "version": "1.0.0",
-  "description": "npm made me this way",
+  "homepage": "https://example.com",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fake/github.git"
   },
-  "main": "index.js",
-  "scripts": {
-    "test": "tape"
-  }
+  "main": "index.js"
 }
 `,
 		},
 		{
 			code: `{
-	"name": "invalid-top-level-property-order",
-	"scripts": {
-		"test": "tape"
-	},
-	"version": "1.0.0",
-	"description": "npm made me this way",
 	"main": "index.js",
+	"homepage": "https://example.com",
+	"version": "1.0.0",
+	"name": "order-legacy",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/fake/github.git"
-		}
 	}
+}
+`,
+			errors: [
+				{
+					message:
+						"Package top-level properties are not ordered in the npm standard way. Run the ESLint auto-fixer to correct.",
+				},
+			],
+			filename: "package.json",
+			options: [{ order: "legacy" }],
+			output: `{
+  "name": "order-legacy",
+  "version": "1.0.0",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fake/github.git"
+  },
+  "homepage": "https://example.com"
+}
+`,
+		},
+		{
+			code: `{
+	"main": "index.js",
+	"homepage": "https://example.com",
+	"version": "1.0.0",
+	"name": "order-legacy",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/fake/github.git"
+	}
+}
 `,
 			errors: [
 				{
@@ -141,51 +120,48 @@ ruleTester.run("order-properties", rule, {
 			options: [{ order: ["version", "name", "repository"] }],
 			output: `{
   "version": "1.0.0",
-  "name": "invalid-top-level-property-order",
+  "name": "order-legacy",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/fake/github.git"
   },
-  "description": "npm made me this way",
-  "main": "index.js",
-  "scripts": {
-    "test": "tape"
-  }
+  "homepage": "https://example.com",
+  "main": "index.js"
 }
 `,
 		},
 	],
 	valid: [
 		`{
-		"name": "treat-yo-self",
-		"version": "1.1.1",
-		"description": "Once a year.",
-		"keywords": [
+	"name": "treat-yo-self",
+	"version": "1.1.1",
+	"description": "Once a year.",
+	"keywords": [
 		"modern",
 		"master"
-		]
-	}`,
+	]
+}`,
 		`{
-		"name": "treat-yo-self",
-		"version": "0.1.0",
-		"private": true,
-		"description": "Once a year.",
-		"keywords": [
+	"name": "treat-yo-self",
+	"version": "0.1.0",
+	"private": true,
+	"description": "Once a year.",
+	"keywords": [
 		"modern",
 		"master"
-		]
-	}
+	]
+}
 	`,
 		{
 			code: `{
-		"version": "1.1.1",
-		"name": "treat-yo-self",
-		"description": "Once a year.",
-		"keywords": [
+	"version": "1.1.1",
+	"name": "treat-yo-self",
+	"description": "Once a year.",
+	"keywords": [
 		"modern",
 		"master"
-		]
-	}
+	]
+}
 	`,
 			options: [{ order: ["version", "name"] }],
 		},
@@ -203,7 +179,8 @@ ruleTester.run("order-properties", rule, {
 		"require": "./index.js"
 	},
 	"main": "index.js"
-	}`,
+}
+`,
 			options: [{ order: "sort-package-json" }],
 		},
 		{
@@ -213,10 +190,10 @@ ruleTester.run("order-properties", rule, {
 	"description": "Once a year.",
 	"main": "index.js",
 	"exports": {
-	"import": "./index.js",
-	"require": "./index.js"
+		"import": "./index.js",
+		"require": "./index.js"
 	}
-	}`,
+}`,
 			options: [{ order: "legacy" }],
 		},
 	],

--- a/src/tests/rules/ruleTester.ts
+++ b/src/tests/rules/ruleTester.ts
@@ -2,17 +2,34 @@ import { RuleTester } from "eslint";
 
 import type { PackageJsonRuleModule } from "../../createRule.js";
 
+export type JsonRuleTesterRun = (
+	name: string,
+	rule: PackageJsonRuleModule,
+	tests: {
+		invalid?: RuleTester.InvalidTestCase[] | undefined;
+		valid?: (RuleTester.ValidTestCase | string)[] | undefined;
+	},
+) => void;
+
 export type JsonRuleTester = RuleTester & {
-	run: (
-		name: string,
-		rule: PackageJsonRuleModule,
-		tests: {
-			invalid?: RuleTester.InvalidTestCase[] | undefined;
-			valid?: (RuleTester.ValidTestCase | string)[] | undefined;
-		},
-	) => void;
+	run: JsonRuleTesterRun;
 };
 
 export const ruleTester = new RuleTester({
 	parser: require.resolve("jsonc-eslint-parser"),
 }) as JsonRuleTester;
+
+const originalRun = ruleTester.run;
+
+ruleTester.run = (name, rule, tests) => {
+	originalRun.call(ruleTester, name, rule as PackageJsonRuleModule, {
+		invalid: tests.invalid?.map((test) => ({
+			filename: "package.json",
+			...test,
+		})),
+		valid: tests.valid?.map((test) => ({
+			filename: "package.json",
+			...(typeof test === "string" ? { code: test } : { ...test }),
+		})),
+	});
+};


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #127; fixes #128
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes #127 by providing a default `filename` for `invalid` and `valid` cases. Also fixes #128's discovered issues as a result. 