### PR TITLE
feat: added valid-name rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [sort-collections](docs/rules/sort-collections.md)                       | Dependencies, scripts, and configuration values must be declared in alphabetical order.         | ✅  | 🔧 |    |
 | [unique-dependencies](docs/rules/unique-dependencies.md)                 | Enforce that if repository directory is specified, it matches the path to the package.json file | ✅  |    | 💡 |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)           | Checks existence of local dependencies in the package.json                                      | ✅  |    |    |
+| [valid-name](docs/rules/valid-name.md)                                   | Enforce that package names are valid npm package names                                          | ✅  |    | 💡 |
 | [valid-package-def](docs/rules/valid-package-def.md)                     | Enforce that package.json has all properties required by the npm spec                           | ✅  |    |    |
 | [valid-repository-directory](docs/rules/valid-repository-directory.md)   | Enforce that if repository directory is specified, it matches the path to the package.json file | ✅  |    | 💡 |
 

--- a/docs/rules/valid-name.md
+++ b/docs/rules/valid-name.md
@@ -1,0 +1,28 @@
+# Enforce that package names are valid npm package names (`package-json/valid-name`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+<!-- end auto-generated rule header -->
+
+This rule applies two validations to the `"name"` property:
+
+-   It must be a string rather than any other data type
+-   It should pass [`validate-npm-package-name`](https://www.npmjs.com/package/validate-npm-package-name) validation
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"name": "Exciting! Package! Name!"
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"name": "exciting-package-name"
+}
+```

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
 	},
 	"dependencies": {
 		"package-json-validator": "^0.6.3",
-		"sort-package-json": "^1.57.0"
+		"sort-package-json": "^1.57.0",
+		"validate-npm-package-name": "^5.0.0"
 	},
 	"devDependencies": {
 		"@release-it/conventional-changelog": "^8.0.1",
@@ -59,6 +60,7 @@
 		"@types/estree": "^1.0.5",
 		"@types/node": "^20.11.5",
 		"@types/package-json-validator": "^0.6.1",
+		"@types/validate-npm-package-name": "^4.0.2",
 		"@typescript-eslint/eslint-plugin": "^6.19.0",
 		"@typescript-eslint/parser": "^6.19.0",
 		"@vitest/coverage-v8": "^1.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   sort-package-json:
     specifier: ^1.57.0
     version: 1.57.0
+  validate-npm-package-name:
+    specifier: ^5.0.0
+    version: 5.0.0
 
 devDependencies:
   '@release-it/conventional-changelog':
@@ -28,6 +31,9 @@ devDependencies:
   '@types/package-json-validator':
     specifier: ^0.6.1
     version: 0.6.1
+  '@types/validate-npm-package-name':
+    specifier: ^4.0.2
+    version: 4.0.2
   '@typescript-eslint/eslint-plugin':
     specifier: ^6.19.0
     version: 6.19.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3)
@@ -1478,6 +1484,10 @@ packages:
     resolution: {integrity: sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==}
     dev: true
 
+  /@types/validate-npm-package-name@4.0.2:
+    resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+    dev: true
+
   /@typescript-eslint/eslint-plugin@6.19.0(@typescript-eslint/parser@6.19.0)(eslint@8.56.0)(typescript@5.3.3):
     resolution: {integrity: sha512-DUCUkQNklCQYnrBSSikjVChdc84/vMPDQSgJTHBZ64G9bA9w0Crc0rd2diujKbTdp6w2J47qkeHQLoi0rpLCdg==}
     engines: {node: ^16.0.0 || >=18.0.0}
@@ -2104,7 +2114,6 @@ packages:
     resolution: {integrity: sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==}
     dependencies:
       semver: 7.5.4
-    dev: true
 
   /bundle-name@3.0.0:
     resolution: {integrity: sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==}
@@ -5058,7 +5067,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yallist: 4.0.0
-    dev: true
 
   /lru-cache@7.18.3:
     resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
@@ -6538,7 +6546,6 @@ packages:
     hasBin: true
     dependencies:
       lru-cache: 6.0.0
-    dev: true
 
   /set-function-length@1.1.1:
     resolution: {integrity: sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==}
@@ -7395,7 +7402,6 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       builtins: 5.0.1
-    dev: true
 
   /version-selector-type@3.0.0:
     resolution: {integrity: sha512-PSvMIZS7C1MuVNBXl/CDG2pZq8EXy/NW2dHIdm3bVP5N0PC8utDK8ttXLXj44Gn3J0lQE3U7Mpm1estAOd+eiA==}
@@ -7681,7 +7687,6 @@ packages:
 
   /yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
-    dev: true
 
   /yaml-eslint-parser@1.2.2:
     resolution: {integrity: sha512-pEwzfsKbTrB8G3xc/sN7aw1v6A6c/pKxLAkjclnAyo5g5qOh6eL9WGu0o3cSDQZKrTNk4KL4lQSwZW+nBkANEg==}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import preferRepositoryShorthand from "./rules/prefer-repository-shorthand.js";
 import sortCollections from "./rules/sort-collections.js";
 import uniqueDependencies from "./rules/unique-dependencies.js";
 import validLocalDependency from "./rules/valid-local-dependency.js";
+import validName from "./rules/valid-name.js";
 import validPackageDef from "./rules/valid-package-def.js";
 import validRepositoryDirectory from "./rules/valid-repository-directory.js";
 
@@ -12,6 +13,7 @@ export const rules = {
 	"sort-collections": sortCollections,
 	"unique-dependencies": uniqueDependencies,
 	"valid-local-dependency": validLocalDependency,
+	"valid-name": validName,
 	"valid-package-def": validPackageDef,
 	"valid-repository-directory": validRepositoryDirectory,
 };

--- a/src/rules/valid-name.ts
+++ b/src/rules/valid-name.ts
@@ -1,0 +1,57 @@
+import type { AST as JsonAST } from "jsonc-eslint-parser";
+
+import * as ESTree from "estree";
+import validate from "validate-npm-package-name";
+
+import { createRule } from "../createRule.js";
+
+export default createRule({
+	create(context) {
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=name]"(
+				node: JsonAST.JSONProperty,
+			) {
+				if (
+					node.value.type !== "JSONLiteral" ||
+					typeof node.value.value !== "string"
+				) {
+					context.report({
+						messageId: "type",
+						node: node.value as unknown as ESTree.Node,
+					});
+					return;
+				}
+
+				const { errors, warnings } = validate(node.value.value);
+				const complaints = [...(errors ?? []), ...(warnings ?? [])];
+				if (!complaints.length) {
+					return;
+				}
+
+				context.report({
+					data: {
+						complaints: complaints
+							.map((error) => error.substring(0, error.length))
+							.join("; "),
+					},
+					messageId: "invalid",
+					node: node.value as unknown as ESTree.Node,
+				});
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: "Best Practices",
+			description:
+				"Enforce that package names are valid npm package names",
+			recommended: true,
+		},
+		hasSuggestions: true,
+		messages: {
+			invalid: "Invalid npm package name: {{ complaints }}.",
+			type: '"name" should be a string.',
+		},
+	},
+});

--- a/src/tests/rules/valid-name.test.ts
+++ b/src/tests/rules/valid-name.test.ts
@@ -1,0 +1,95 @@
+import rule from "../../rules/valid-name.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-name", rule, {
+	invalid: [
+		{
+			code: `{
+	"name": null
+}
+`,
+			errors: [
+				{
+					column: 10,
+					endColumn: 14,
+					line: 2,
+					messageId: "type",
+				},
+			],
+		},
+		{
+			code: `{
+	"name": 123
+}
+`,
+			errors: [
+				{
+					messageId: "type",
+				},
+			],
+		},
+		{
+			code: `{
+	"name": ""
+}
+`,
+			errors: [
+				{
+					data: {
+						complaints: "name length must be greater than zero",
+					},
+					messageId: "invalid",
+				},
+			],
+		},
+		{
+			code: `{
+	"name": "excited!"
+}
+`,
+			errors: [
+				{
+					data: {
+						complaints:
+							'name can no longer contain special characters ("~\'!()*")',
+					},
+					messageId: "invalid",
+				},
+			],
+		},
+		{
+			code: `{
+	"name": "$!"
+}
+`,
+			errors: [
+				{
+					data: {
+						complaints:
+							'name can only contain URL-friendly characters; name can no longer contain special characters ("~\'!()*")',
+					},
+					messageId: "invalid",
+				},
+			],
+		},
+		{
+			code: `{
+	"name": " leading-space:and:weirdchars!"
+}
+`,
+			errors: [
+				{
+					data: {
+						complaints:
+							'name cannot contain leading or trailing spaces; name can only contain URL-friendly characters; name can no longer contain special characters ("~\'!()*")',
+					},
+					messageId: "invalid",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		//
+	],
+});

--- a/src/tests/rules/valid-name.test.ts
+++ b/src/tests/rules/valid-name.test.ts
@@ -74,7 +74,7 @@ ruleTester.run("valid-name", rule, {
 		},
 		{
 			code: `{
-	"name": " leading-space:and:weirdchars!"
+	"name": " leading-space:and:weird:chars!"
 }
 `,
 			errors: [

--- a/src/tests/rules/valid-name.test.ts
+++ b/src/tests/rules/valid-name.test.ts
@@ -90,6 +90,7 @@ ruleTester.run("valid-name", rule, {
 	],
 	valid: [
 		"{}",
-		//
+		`{ "name": "valid-package-name" }`,
+		`{ "name": "@scoped/valid-package-name" }`,
 	],
 });


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #131
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the rule using the same `validate-npm-package-name` dependency as `npm-package-json-lint`.