### PR TITLE
feat: added valid-version rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-name](docs/rules/valid-name.md)                                   | Enforce that package names are valid npm package names                                          | ✅  |    | 💡 |
 | [valid-package-def](docs/rules/valid-package-def.md)                     | Enforce that package.json has all properties required by the npm spec                           | ✅  |    |    |
 | [valid-repository-directory](docs/rules/valid-repository-directory.md)   | Enforce that if repository directory is specified, it matches the path to the package.json file | ✅  |    | 💡 |
+| [valid-version](docs/rules/valid-version.md)                             | Enforce that package versions are valid semver specifiers                                       | ✅  |    | 💡 |
 
 <!-- end auto-generated rules list -->
 <!-- prettier-ignore-end -->

--- a/docs/rules/valid-version.md
+++ b/docs/rules/valid-version.md
@@ -1,0 +1,28 @@
+# Enforce that package versions are valid semver specifiers (`package-json/valid-version`)
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/developer-guide/working-with-rules#providing-suggestions).
+
+<!-- end auto-generated rule header -->
+
+This rule applies two validations to the `"name"` property:
+
+-   It must be a string rather than any other data type
+-   It should pass [`semver`](https://www.npmjs.com/package/semver) validation
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"version": "1"
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"version": "1.2.3"
+}
+```

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 	},
 	"dependencies": {
 		"package-json-validator": "^0.6.3",
+		"semver": "^7.5.4",
 		"sort-package-json": "^1.57.0",
 		"validate-npm-package-name": "^5.0.0"
 	},
@@ -60,6 +61,7 @@
 		"@types/estree": "^1.0.5",
 		"@types/node": "^20.11.5",
 		"@types/package-json-validator": "^0.6.1",
+		"@types/semver": "^7.5.6",
 		"@types/validate-npm-package-name": "^4.0.2",
 		"@typescript-eslint/eslint-plugin": "^6.19.0",
 		"@typescript-eslint/parser": "^6.19.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ dependencies:
   package-json-validator:
     specifier: ^0.6.3
     version: 0.6.3
+  semver:
+    specifier: ^7.5.4
+    version: 7.5.4
   sort-package-json:
     specifier: ^1.57.0
     version: 1.57.0
@@ -31,6 +34,9 @@ devDependencies:
   '@types/package-json-validator':
     specifier: ^0.6.1
     version: 0.6.1
+  '@types/semver':
+    specifier: ^7.5.6
+    version: 7.5.6
   '@types/validate-npm-package-name':
     specifier: ^4.0.2
     version: 4.0.2
@@ -1476,8 +1482,8 @@ packages:
     resolution: {integrity: sha512-Yll76ZHikRFCyz/pffKGjrCwe/le2CDwOP5F210KQo27kpRE46U2rDnzikNlVn6/ezH3Mhn46bJMTfeVTtcYMg==}
     dev: true
 
-  /@types/semver@7.5.5:
-    resolution: {integrity: sha512-+d+WYC1BxJ6yVOgUgzK8gWvp5qF8ssV5r4nsDcZWKRWcDQLQ619tvWAxJQYGgBrO1MnLJC7a5GtiYsAoQ47dJg==}
+  /@types/semver@7.5.6:
+    resolution: {integrity: sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==}
     dev: true
 
   /@types/unist@2.0.10:
@@ -1635,7 +1641,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.5
+      '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.3.3)
@@ -1655,7 +1661,7 @@ packages:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.56.0)
       '@types/json-schema': 7.0.15
-      '@types/semver': 7.5.5
+      '@types/semver': 7.5.6
       '@typescript-eslint/scope-manager': 6.19.0
       '@typescript-eslint/types': 6.19.0
       '@typescript-eslint/typescript-estree': 6.19.0(typescript@5.3.3)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import validLocalDependency from "./rules/valid-local-dependency.js";
 import validName from "./rules/valid-name.js";
 import validPackageDef from "./rules/valid-package-def.js";
 import validRepositoryDirectory from "./rules/valid-repository-directory.js";
+import validVersion from "./rules/valid-version.js";
 
 export const rules = {
 	"order-properties": orderProperties,
@@ -16,6 +17,7 @@ export const rules = {
 	"valid-name": validName,
 	"valid-package-def": validPackageDef,
 	"valid-repository-directory": validRepositoryDirectory,
+	"valid-version": validVersion,
 };
 
 export const configs = {

--- a/src/rules/valid-version.ts
+++ b/src/rules/valid-version.ts
@@ -1,0 +1,48 @@
+import type { AST as JsonAST } from "jsonc-eslint-parser";
+
+import * as ESTree from "estree";
+import semver from "semver";
+
+import { createRule } from "../createRule.js";
+
+export default createRule({
+	create(context) {
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=version]"(
+				node: JsonAST.JSONProperty,
+			) {
+				if (
+					node.value.type !== "JSONLiteral" ||
+					typeof node.value.value !== "string"
+				) {
+					context.report({
+						messageId: "type",
+						node: node.value as unknown as ESTree.Node,
+					});
+					return;
+				}
+
+				if (!semver.valid(node.value.value)) {
+					context.report({
+						messageId: "invalid",
+						node: node.value as unknown as ESTree.Node,
+					});
+				}
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: "Best Practices",
+			description:
+				"Enforce that package versions are valid semver specifiers",
+			recommended: true,
+		},
+		hasSuggestions: true,
+		messages: {
+			invalid: "Version is not a valid semver specifier.",
+			type: '"version" should be a string.',
+		},
+	},
+});

--- a/src/tests/rules/valid-version.test.ts
+++ b/src/tests/rules/valid-version.test.ts
@@ -1,0 +1,51 @@
+import rule from "../../rules/valid-version.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-version", rule, {
+	invalid: [
+		{
+			code: `{
+	"version": null
+}
+`,
+			errors: [
+				{
+					column: 13,
+					endColumn: 17,
+					line: 2,
+					messageId: "type",
+				},
+			],
+		},
+		{
+			code: `{ "version": 123 }`,
+			errors: [{ messageId: "type" }],
+		},
+		{
+			code: `{ "version": "" }`,
+			errors: [{ messageId: "invalid" }],
+		},
+		{
+			code: `{ "version": "latest" }`,
+			errors: [{ messageId: "invalid" }],
+		},
+		{
+			code: `{ "version": "?!" }`,
+			errors: [{ messageId: "invalid" }],
+		},
+		{
+			code: `{ "version": "1" }`,
+			errors: [{ messageId: "invalid" }],
+		},
+		{
+			code: `{ "version": "1.2" }`,
+			errors: [{ messageId: "invalid" }],
+		},
+	],
+	valid: [
+		"{}",
+		`{ "version": "1.2.3" }`,
+		`{ "version": "1.2.3-beta" }`,
+		`{ "version": "1.2.3-beta.0" }`,
+	],
+});


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #130
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds the rule using the standard `semver` package used by `npm-package-json-lint`.
