### PR TITLE
fix: incorrect example in 'sort-collections'

### DIFF
--- a/docs/rules/sort-collections.md
+++ b/docs/rules/sort-collections.md
@@ -19,15 +19,19 @@ This rule aims to keep the dependency collections sorted in every commit.
 
 The following patterns are considered errors:
 
+<!-- eslint-disable jsonc/sort-keys -->
+
 ```json
 {
 	"scripts": {
 		"lint": "eslint .",
-		"start": "node server.js",
-		"test": "jest"
+		"test": "jest",
+		"start": "node server.js"
 	}
 }
 ```
+
+<!-- eslint-enable jsonc/sort-keys -->
 
 In the above `scripts` collection, `test` should be moved to the last line, after `lint` and `start`.
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #136
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Deactivation of the sorting rule so that the incorrect example remains incorrect after linting.

🌱