### PR TITLE
fix: support Windows paths, again

### DIFF
--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -3,7 +3,7 @@ import type * as ESTree from "estree";
 import { AST, Rule, SourceCode } from "eslint";
 import { AST as JsonAST, RuleListener } from "jsonc-eslint-parser";
 
-import { isPackageJson } from "./utils/isPackageJson";
+import { isPackageJson } from "./utils/isPackageJson.js";
 
 export type JsonAstBodyProperty = JsonAST.JSONProperty & {
 	value: string;

--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -3,8 +3,7 @@ import type * as ESTree from "estree";
 import { AST, Rule, SourceCode } from "eslint";
 import { AST as JsonAST, RuleListener } from "jsonc-eslint-parser";
 
-const isPackageJson = (filePath: string) =>
-	filePath.endsWith("/package.json") || filePath === "package.json";
+import { isPackageJson } from "./utils/isPackageJson";
 
 export type JsonAstBodyProperty = JsonAST.JSONProperty & {
 	value: string;

--- a/src/utils/isPackageJson.test.ts
+++ b/src/utils/isPackageJson.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+
+import { isPackageJson } from "./isPackageJson.js";
+
+describe("isPackageJson", () => {
+	test.each([
+		["", false],
+		["-", false],
+		["other", false],
+		["package.js", false],
+		["package.jsx", false],
+		["-package.json", false],
+		["prefix-package.json", false],
+		["package.json.json", false],
+		["package.package.json", false],
+		["package.json.package.json", false],
+		["package.json-package.json", false],
+		["package.json", true],
+		["/package.json", true],
+		["\\package.json", true],
+		["prefix/package.json", true],
+		["prefix\\package.json", true],
+		["mixed\\prefix/package.json", true],
+		["mixed/prefix\\package.json", true],
+	])(`%s`, (input, expected) => {
+		expect(isPackageJson(input)).toBe(expected);
+	});
+});

--- a/src/utils/isPackageJson.ts
+++ b/src/utils/isPackageJson.ts
@@ -1,0 +1,2 @@
+export const isPackageJson = (filePath: string) =>
+	/(?:^|[/\\])package.json$/.test(filePath);


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #142
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Re-applies #30 to the `main` branch.