### PR TITLE
fix(valid-package-def): ignore pnpm workspace protocol

### DIFF
--- a/src/rules/valid-package-def.ts
+++ b/src/rules/valid-package-def.ts
@@ -7,7 +7,7 @@ import { createRule } from "../createRule.js";
 // so we disable some other errors here.
 const unusedErrorPatterns = [
 	/^Url not valid/i,
-	/^Invalid version range for .+?: (?:file|npm):/i,
+	/^Invalid version range for .+?: (?:file|npm|workspace):/i,
 	/^author field should have name/i,
 ];
 

--- a/src/tests/rules/valid-package-def.test.ts
+++ b/src/tests/rules/valid-package-def.test.ts
@@ -72,7 +72,8 @@ ruleTester.run("valid-package-def", rule, {
   "license": "ISC",
   "dependencies": {
     "foo": "npm:bar@^1.0.0",
-    "baz": "file:../baz"
+    "baz": "file:../baz",
+    "bar": "workspace:*"
   }
 }`,
 			filename: "package.json",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #251
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

pnpm has a "workspace protocol" (link) that allows you to explicitly say a package lives in your current workspace. Ignore this when doing package.json validation by adding `workspace` to the ignore glob.
