### PR TITLE
fix: skip check for name to match npm package when private is true

### DIFF
--- a/src/rules/valid-name.ts
+++ b/src/rules/valid-name.ts
@@ -22,15 +22,16 @@ export const rule = createRule({
 					return;
 				}
 
+				const privateField = node.parent.properties.find(
+					(p) =>
+						p.key.type === "JSONLiteral" &&
+						p.key.value === "private",
+				);
 				if (
-					node.parent.properties.some(
-						(p) =>
-							p.key.type === "JSONLiteral" &&
-							p.key.value === "private" &&
-							p.value.type === "JSONLiteral" &&
-							(p.value.value === true ||
-								p.value.value === "true"),
-					)
+					privateField &&
+					privateField.value.type === "JSONLiteral" &&
+					(privateField.value.value === true ||
+						privateField.value.value === "true")
 				) {
 					return;
 				}

--- a/src/rules/valid-name.ts
+++ b/src/rules/valid-name.ts
@@ -22,6 +22,19 @@ export const rule = createRule({
 					return;
 				}
 
+				if (
+					node.parent.properties.some(
+						(p) =>
+							p.key.type === "JSONLiteral" &&
+							p.key.value === "private" &&
+							p.value.type === "JSONLiteral" &&
+							(p.value.value === true ||
+								p.value.value === "true"),
+					)
+				) {
+					return;
+				}
+
 				const { errors, warnings } = validate(node.value.value);
 				const complaints = [...(errors ?? []), ...(warnings ?? [])];
 				if (!complaints.length) {

--- a/src/tests/rules/valid-name.test.ts
+++ b/src/tests/rules/valid-name.test.ts
@@ -87,10 +87,28 @@ ruleTester.run("valid-name", rule, {
 				},
 			],
 		},
+		{
+			code: `{
+	"name": "InvalidPackageNameWithPrivateFalse",
+	"private": false
+}
+`,
+			errors: [
+				{
+					data: {
+						complaints:
+							"name can no longer contain capital letters",
+					},
+					messageId: "invalid",
+				},
+			],
+		},
 	],
 	valid: [
 		"{}",
 		`{ "name": "valid-package-name" }`,
 		`{ "name": "@scoped/valid-package-name" }`,
+		`{ "name": "InvalidPackageNameWithPrivateTrue", "private": true }`,
+		`{ "name": "InvalidPackageNameWithPrivateTrue", "private": "true" }`,
 	],
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #000
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

When I write a project that is not a npm package, we do not need to make the name field match the npm package rules.

Sorry for not creating an issue first(I am lazy), feel free to close this PR if you do not want to make this change.
