### PR TITLE
fix: add plugin export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,5 @@ export const configs = {
 		rules: recommendedRuleSettings,
 	},
 };
+
+export default plugin;


### PR DESCRIPTION
## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

I'd like to be able to setup the plugin manually. Why don't you export it by default?