### PR TITLE
fix: add sorting exports field

### DIFF
--- a/docs/rules/sort-collections.md
+++ b/docs/rules/sort-collections.md
@@ -97,7 +97,14 @@ Example:
 Defaults:
 
 ```json
-["scripts", "devDependencies", "dependencies", "peerDependencies", "config"]
+[
+	"scripts",
+	"devDependencies",
+	"dependencies",
+	"peerDependencies",
+	"config",
+	"exports"
+]
 ```
 
 This rule is **autofixable**; run `eslint` with the `--fix` option to sort any incorrect collections in place.

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -9,6 +9,7 @@ const defaultCollections = [
 	"dependencies",
 	"peerDependencies",
 	"config",
+	"exports",
 ];
 
 type Options = string[];

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -28,6 +28,35 @@ ruleTester.run("sort-collections", rule, {
   }
 }`,
 		},
+		{
+			code: `{
+	"exports": {
+		"./package.json": "./package.json",
+		".": {
+			"import": "./index.mjs",
+			"require": "./index.js",
+			"types": "./index.d.ts"
+		}
+	}
+}`,
+			errors: [
+				{
+					message: "Package exports are not alphabetized",
+					type: "JSONProperty",
+				},
+			],
+			filename: "package.json",
+			output: `{
+	"exports": {
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    },
+    "./package.json": "./package.json"
+  }
+}`,
+		},
 	],
 
 	valid: [


### PR DESCRIPTION
Added sorting `exports` in `package.json`.

Fail:

```json
  "exports": {
    "./package.json": "./package.json"
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.js",
      "types": "./dist/index.d.ts"
    },
  },
```

Pass:

```json
  "exports": {
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.js",
      "types": "./dist/index.d.ts"
    },
    "./package.json": "./package.json"
  },
```


## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken
