### PR TITLE
docs: fix jsonc-eslint-parser installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm install eslint eslint-plugin-package-json --save-dev
 
 ### Flat Config
 
-This plugin's recommended configuration enables its rules on `**/package.json` files, parsing them with [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser):
+This plugin's recommended configuration enables its rules on `**/package.json` files, parsing them with [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser).
 
 In your ESLint configuration file:
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@
 
 ## Installation
 
-This package requires [ESLint](http://eslint.org) 8 and [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser):
+This package requires [ESLint](http://eslint.org) >=8:
 
 ```shell
-npm install eslint eslint-plugin-package-json jsonc-eslint-parser --save-dev
+npm install eslint eslint-plugin-package-json --save-dev
 ```
 
 ## Usage
@@ -63,7 +63,13 @@ See [ESLint's _Configuration Files_ guide](https://eslint.org/docs/latest/use/co
 
 ### Legacy Config
 
-Add an override to your ESLint configuration file that specifies this plugin, [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser), and its recommended rules for your `package.json` file:
+Usage with ESLint's legacy ("eslintrc") format requires also installing [`jsonc-eslint-parser`](https://github.com/ota-meshi/jsonc-eslint-parser):
+
+```shell
+npm install jsonc-eslint-parser --save-dev
+```
+
+Add an override to your ESLint configuration file that specifies `jsonc-eslint-parser`, this plugin, and its recommended rules for your `package.json` file:
 
 ```js
 module.exports = {


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #49
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Moves any mention of installing `jsonc-eslint-parser` to just within the _Legacy Config_ section.

💖 