### PR TITLE
docs: add `Development` section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,11 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 These rules only run on `package.json` files; they will ignore all other files being linted.
 They can lint `package.json` files at project root and in any subfolder of the project, making this plugin great for monorepos.
 
+## Development
+
+See [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md), then [`.github/DEVELOPMENT.md`](./.github/DEVELOPMENT.md).
+Thanks! 💖
+
 ## Contributors
 
 <!-- spellchecker: disable -->


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #661
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Add a `Development` section in the README for better discoverability.
