### PR TITLE
refactor: resolve multiple eslint plugin violations

### DIFF
--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -79,6 +79,9 @@ export const rule = createRule<Options>({
 					}
 
 					context.report({
+						data: {
+							property: value,
+						},
 						fix(fixer) {
 							const { indent, type } = detectIndent(text);
 							const endCharacters = text.endsWith("\n")
@@ -101,15 +104,12 @@ export const rule = createRule<Options>({
 							);
 						},
 						loc: properties[i].loc,
-						// eslint-disable-next-line eslint-plugin/prefer-message-ids
-						message: `Package top-level property "${value}" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.`,
+						messageId: "incorrectOrder",
 					});
 				}
 			},
 		};
 	},
-
-	// eslint-disable-next-line eslint-plugin/prefer-message-ids, eslint-plugin/require-meta-type
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -118,6 +118,10 @@ export const rule = createRule<Options>({
 			recommended: true,
 		},
 		fixable: "code",
+		messages: {
+			incorrectOrder:
+				'Package top-level property "{{property}}" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+		},
 		schema: [
 			{
 				properties: {
@@ -139,5 +143,6 @@ export const rule = createRule<Options>({
 				type: "object",
 			},
 		],
+		type: "layout",
 	},
 });

--- a/src/rules/repository-shorthand.ts
+++ b/src/rules/repository-shorthand.ts
@@ -131,7 +131,6 @@ export const rule = createRule<Options>({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/require-meta-type
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -156,5 +155,6 @@ export const rule = createRule<Options>({
 				type: "object",
 			},
 		],
+		type: "suggestion",
 	},
 });

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -115,8 +115,7 @@ export const rule = createRule<Options>({
 								);
 							},
 							loc: collection.loc,
-							// eslint-disable-next-line eslint-plugin/prefer-message-ids
-							message: "Package {{ key }} are not alphabetized",
+							messageId: "notAlphabetized",
 							node: node as unknown as ESTree.Node,
 						});
 					}
@@ -125,7 +124,6 @@ export const rule = createRule<Options>({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/prefer-message-ids, eslint-plugin/require-meta-type
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -134,6 +132,9 @@ export const rule = createRule<Options>({
 			recommended: true,
 		},
 		fixable: "code",
+		messages: {
+			notAlphabetized: "Package {{ key }} are not alphabetized",
+		},
 		schema: [
 			{
 				items: {
@@ -142,5 +143,6 @@ export const rule = createRule<Options>({
 				type: "array",
 			},
 		],
+		type: "layout",
 	},
 });

--- a/src/rules/unique-dependencies.ts
+++ b/src/rules/unique-dependencies.ts
@@ -92,7 +92,6 @@ export const rule = createRule({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/require-meta-schema, eslint-plugin/require-meta-type
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -106,5 +105,7 @@ export const rule = createRule({
 				"Package name is overridden by a duplicate listing later on.",
 			remove: "Remove this redundant dependency listing.",
 		},
+		schema: [],
+		type: "suggestion",
 	},
 });

--- a/src/rules/valid-local-dependency.ts
+++ b/src/rules/valid-local-dependency.ts
@@ -31,15 +31,21 @@ export const rule = createRule({
 							try {
 								if (!require.resolve(filePath)) {
 									context.report({
-										// eslint-disable-next-line eslint-plugin/prefer-message-ids
-										message: `The package ${key} does not exist given the specified path: ${value}.`,
+										data: {
+											package: key,
+											path: value,
+										},
+										messageId: "invalidPath",
 										node: context.sourceCode.ast,
 									});
 								}
 							} catch {
 								context.report({
-									// eslint-disable-next-line eslint-plugin/prefer-message-ids
-									message: `The package ${key} does not exist given the specified path: ${value}.`,
+									data: {
+										package: key,
+										path: value,
+									},
+									messageId: "invalidPath",
 									node: context.sourceCode.ast,
 								});
 							}
@@ -58,7 +64,6 @@ export const rule = createRule({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/require-meta-schema, eslint-plugin/require-meta-type, eslint-plugin/prefer-message-ids
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -66,5 +71,11 @@ export const rule = createRule({
 				"Checks existence of local dependencies in the package.json",
 			recommended: true,
 		},
+		messages: {
+			invalidPath:
+				"The package {{package}} does not exist given the specified path: {{path}}.",
+		},
+		schema: [],
+		type: "problem",
 	},
 });

--- a/src/rules/valid-name.ts
+++ b/src/rules/valid-name.ts
@@ -55,7 +55,6 @@ export const rule = createRule({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/require-meta-type, eslint-plugin/require-meta-schema
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -67,5 +66,7 @@ export const rule = createRule({
 			invalid: "Invalid npm package name: {{ complaints }}.",
 			type: '"name" should be a string.',
 		},
+		schema: [],
+		type: "problem",
 	},
 });

--- a/src/rules/valid-package-def.ts
+++ b/src/rules/valid-package-def.ts
@@ -35,7 +35,7 @@ export const rule = createRule({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/prefer-message-ids, eslint-plugin/require-meta-type, eslint-plugin/require-meta-schema
+	// eslint-disable-next-line eslint-plugin/prefer-message-ids
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -43,5 +43,7 @@ export const rule = createRule({
 				"Enforce that package.json has all properties required by the npm spec",
 			recommended: true,
 		},
+		schema: [],
+		type: "problem",
 	},
 });

--- a/src/rules/valid-repository-directory.ts
+++ b/src/rules/valid-repository-directory.ts
@@ -112,13 +112,13 @@ export const rule = createRule({
 							node: directoryProperty.value as unknown as ESTree.Node,
 							suggest: [
 								{
+									data: { expected },
 									fix(fixer) {
 										return fixer.replaceText(
 											directoryProperty.value as unknown as ESTree.Node,
 											`"${expected}"`,
 										);
 									},
-									// eslint-disable-next-line eslint-plugin/no-missing-placeholders
 									messageId: "replace",
 								},
 							],
@@ -129,7 +129,6 @@ export const rule = createRule({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/require-meta-type, eslint-plugin/require-meta-schema
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -142,5 +141,7 @@ export const rule = createRule({
 			mismatched: "Directory does not match package.json directory.",
 			replace: "Replace with '{{ expected }}'.",
 		},
+		schema: [],
+		type: "suggestion",
 	},
 });

--- a/src/rules/valid-version.ts
+++ b/src/rules/valid-version.ts
@@ -32,7 +32,6 @@ export const rule = createRule({
 		};
 	},
 
-	// eslint-disable-next-line eslint-plugin/require-meta-type, eslint-plugin/require-meta-schema
 	meta: {
 		docs: {
 			category: "Best Practices",
@@ -44,5 +43,7 @@ export const rule = createRule({
 			invalid: "Version is not a valid semver specifier.",
 			type: '"version" should be a string.',
 		},
+		schema: [],
+		type: "problem",
 	},
 });

--- a/src/tests/rules/order-properties.test.ts
+++ b/src/tests/rules/order-properties.test.ts
@@ -17,24 +17,24 @@ ruleTester.run("order-properties", rule, {
 `,
 			errors: [
 				{
-					message:
-						'Package top-level property "main" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "main" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "homepage" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "homepage" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "version" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "version" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "name" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "name" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "repository" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "repository" },
+					messageId: "incorrectOrder",
 				},
 			],
 			filename: "package.json",
@@ -64,16 +64,16 @@ ruleTester.run("order-properties", rule, {
 `,
 			errors: [
 				{
-					message:
-						'Package top-level property "main" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "main" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "version" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "version" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "repository" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "repository" },
+					messageId: "incorrectOrder",
 				},
 			],
 			filename: "package.json",
@@ -103,24 +103,24 @@ ruleTester.run("order-properties", rule, {
 `,
 			errors: [
 				{
-					message:
-						'Package top-level property "main" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "main" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "homepage" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "homepage" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "version" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "version" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "name" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "name" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "repository" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "repository" },
+					messageId: "incorrectOrder",
 				},
 			],
 			filename: "package.json",
@@ -150,24 +150,24 @@ ruleTester.run("order-properties", rule, {
 `,
 			errors: [
 				{
-					message:
-						'Package top-level property "main" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "main" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "homepage" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "homepage" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "version" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "version" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "name" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "name" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "repository" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "repository" },
+					messageId: "incorrectOrder",
 				},
 			],
 			filename: "package.json",
@@ -197,24 +197,24 @@ ruleTester.run("order-properties", rule, {
 `,
 			errors: [
 				{
-					message:
-						'Package top-level property "main" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "main" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "homepage" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "homepage" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "version" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "version" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "name" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "name" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "repository" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "repository" },
+					messageId: "incorrectOrder",
 				},
 			],
 			filename: "package.json",
@@ -245,24 +245,24 @@ ruleTester.run("order-properties", rule, {
 `,
 			errors: [
 				{
-					message:
-						'Package top-level property "main" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "main" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "homepage" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "homepage" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "version" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "version" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "name" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "name" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "repository" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "repository" },
+					messageId: "incorrectOrder",
 				},
 			],
 			filename: "package.json",
@@ -293,24 +293,24 @@ ruleTester.run("order-properties", rule, {
 `,
 			errors: [
 				{
-					message:
-						'Package top-level property "main" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "main" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "homepage" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "homepage" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "version" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "version" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "name" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "name" },
+					messageId: "incorrectOrder",
 				},
 				{
-					message:
-						'Package top-level property "repository" is not ordered in the npm standard way. Run the ESLint auto-fixer to correct.',
+					data: { property: "repository" },
+					messageId: "incorrectOrder",
 				},
 			],
 			filename: "package.json",

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -16,7 +16,8 @@ ruleTester.run("sort-collections", rule, {
 }`,
 			errors: [
 				{
-					message: "Package scripts are not alphabetized",
+					data: { key: "scripts" },
+					messageId: "notAlphabetized",
 					type: "JSONProperty",
 				},
 			],
@@ -39,7 +40,8 @@ ruleTester.run("sort-collections", rule, {
 }`,
 			errors: [
 				{
-					message: "Package scripts are not alphabetized",
+					data: { key: "scripts" },
+					messageId: "notAlphabetized",
 					type: "JSONProperty",
 				},
 			],
@@ -62,7 +64,8 @@ ruleTester.run("sort-collections", rule, {
 }`,
 			errors: [
 				{
-					message: "Package scripts are not alphabetized",
+					data: { key: "scripts" },
+					messageId: "notAlphabetized",
 					type: "JSONProperty",
 				},
 			],
@@ -83,7 +86,8 @@ ruleTester.run("sort-collections", rule, {
 }`,
 			errors: [
 				{
-					message: "Package scripts are not alphabetized",
+					data: { key: "scripts" },
+					messageId: "notAlphabetized",
 					type: "JSONProperty",
 				},
 			],
@@ -104,7 +108,8 @@ ruleTester.run("sort-collections", rule, {
 }`,
 			errors: [
 				{
-					message: "Package scripts are not alphabetized",
+					data: { key: "scripts" },
+					messageId: "notAlphabetized",
 					type: "JSONProperty",
 				},
 			],
@@ -129,7 +134,8 @@ ruleTester.run("sort-collections", rule, {
 }`,
 			errors: [
 				{
-					message: "Package exports are not alphabetized",
+					data: { key: "exports" },
+					messageId: "notAlphabetized",
 					type: "JSONProperty",
 				},
 			],

--- a/src/tests/rules/valid-local-dependency.test.ts
+++ b/src/tests/rules/valid-local-dependency.test.ts
@@ -19,8 +19,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: link:./src/tests/__fixtures__/Invalid-local-dependency.",
+					data: {
+						package: "some-package",
+						path: "link:./src/tests/__fixtures__/Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),
@@ -34,8 +37,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: link:./src/tests/__fixtures__/Invalid-local-dependency.",
+					data: {
+						package: "some-package",
+						path: "link:./src/tests/__fixtures__/Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),
@@ -49,8 +55,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: link:./src/tests/__fixtures__/Invalid-local-dependency.",
+					data: {
+						package: "some-package",
+						path: "link:./src/tests/__fixtures__/Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),
@@ -64,8 +73,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: link:./src/tests/__fixtures__/dependency.",
+					data: {
+						package: "some-package",
+						path: "link:./src/tests/__fixtures__/dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),
@@ -83,12 +95,18 @@ ruleTester.run("valid-local-dependency", rule, {
 					}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: link:./src/tests/__fixtures__/Invalid-local-dependency.",
+					data: {
+						package: "some-package",
+						path: "link:./src/tests/__fixtures__/Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 				{
-					message:
-						"The package peer-package does not exist given the specified path: link:./src/tests/__fixtures__/Invalid-local-dependency.",
+					data: {
+						package: "peer-package",
+						path: "link:./src/tests/__fixtures__/Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),
@@ -103,8 +121,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: link:./src/tests/__fixtures__/Invalid-local-dependency.",
+					data: {
+						package: "some-package",
+						path: "link:./src/tests/__fixtures__/Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),
@@ -117,8 +138,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: link:../Invalid-local-dependency.",
+					data: {
+						package: "some-package",
+						path: "link:../Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName(
@@ -134,8 +158,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: file:./src/tests/__fixtures__/Invalid-local-dependency.",
+					data: {
+						package: "some-package",
+						path: "file:./src/tests/__fixtures__/Invalid-local-dependency",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),
@@ -149,8 +176,11 @@ ruleTester.run("valid-local-dependency", rule, {
 			}`,
 			errors: [
 				{
-					message:
-						"The package some-package does not exist given the specified path: file:./src/tests/__fixtures__/Invalid-local-dependency/gotcha/package.json/gotcha.",
+					data: {
+						package: "some-package",
+						path: "file:./src/tests/__fixtures__/Invalid-local-dependency/gotcha/package.json/gotcha",
+					},
+					messageId: "invalidPath",
 				},
 			],
 			filename: fileName("package.json"),


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #81 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change resolves all of the violations revealed by #708, except for one.  The messages used to report violations in `valid-package-def` are coming from PJV and not maintained by the plugin.  So, unless there's an attempt to map PJV errors to statically defined messages within the rule, that one will need to continue using `message`.

I took my best stab at defining the `type` property for the ones that were missing it.  Let me know if you think any of them should be adjusted.

Closes: #81 