### PR TITLE
chore: use `eslint-fix-utils` for element and property removals

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"@altano/repository-tools": "^0.1.1",
 		"detect-indent": "6.1.0",
 		"detect-newline": "3.1.0",
-		"eslint-fix-utils": "^0.1.0",
+		"eslint-fix-utils": "^0.2.0",
 		"package-json-validator": "^0.8.0",
 		"semver": "^7.5.4",
 		"sort-object-keys": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
 		"@altano/repository-tools": "^0.1.1",
 		"detect-indent": "6.1.0",
 		"detect-newline": "3.1.0",
+		"eslint-fix-utils": "^0.1.0",
 		"package-json-validator": "^0.8.0",
 		"semver": "^7.5.4",
 		"sort-object-keys": "^1.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       detect-newline:
         specifier: 3.1.0
         version: 3.1.0
+      eslint-fix-utils:
+        specifier: ^0.1.0
+        version: 0.1.0(@types/estree@1.0.6)(eslint@9.18.0(jiti@2.4.2))
       package-json-validator:
         specifier: ^0.8.0
         version: 0.8.0
@@ -1820,6 +1823,13 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>= 8.57.1'
+
+  eslint-fix-utils@0.1.0:
+    resolution: {integrity: sha512-wdRrErXHDgdsmPWWOCIeq/wNUksrsRdNYTFur7wCkinCnip6ZBRM8voW28q6+xQEOBOhy6PX+f26xfZXO7fqzA==}
+    engines: {node: '>=18.3.0'}
+    peerDependencies:
+      '@types/estree': '>=1'
+      eslint: '>=8'
 
   eslint-json-compat-utils@0.2.1:
     resolution: {integrity: sha512-YzEodbDyW8DX8bImKhAcCeu/L31Dd/70Bidx2Qex9OFUtgzXLqtfWL4Hr5fM/aCCB8QUZLuJur0S9k6UfgFkfg==}
@@ -5362,6 +5372,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
+
+  eslint-fix-utils@0.1.0(@types/estree@1.0.6)(eslint@9.18.0(jiti@2.4.2)):
+    dependencies:
+      '@types/estree': 1.0.6
+      eslint: 9.18.0(jiti@2.4.2)
 
   eslint-json-compat-utils@0.2.1(eslint@9.18.0(jiti@2.4.2))(jsonc-eslint-parser@2.4.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,8 +18,8 @@ importers:
         specifier: 3.1.0
         version: 3.1.0
       eslint-fix-utils:
-        specifier: ^0.1.0
-        version: 0.1.0(@types/estree@1.0.6)(eslint@9.18.0(jiti@2.4.2))
+        specifier: ^0.2.0
+        version: 0.2.0(@types/estree@1.0.6)(eslint@9.18.0(jiti@2.4.2))
       package-json-validator:
         specifier: ^0.8.0
         version: 0.8.0
@@ -1838,8 +1838,8 @@ packages:
     peerDependencies:
       eslint: '>= 8.57.1'
 
-  eslint-fix-utils@0.1.0:
-    resolution: {integrity: sha512-wdRrErXHDgdsmPWWOCIeq/wNUksrsRdNYTFur7wCkinCnip6ZBRM8voW28q6+xQEOBOhy6PX+f26xfZXO7fqzA==}
+  eslint-fix-utils@0.2.0:
+    resolution: {integrity: sha512-2z/I/1VfyL1mkLjk18W7Q3X+gqzeFmc2aNxSY/RmT6vNPyzQfT1MR/yP/+RUbqRuNUNMhTTYeP7AK7UUpcUD4w==}
     engines: {node: '>=18.3.0'}
     peerDependencies:
       '@types/estree': '>=1'
@@ -5358,7 +5358,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-fix-utils@0.1.0(@types/estree@1.0.6)(eslint@9.18.0(jiti@2.4.2)):
+  eslint-fix-utils@0.2.0(@types/estree@1.0.6)(eslint@9.18.0(jiti@2.4.2)):
     dependencies:
       '@types/estree': 1.0.6
       eslint: 9.18.0(jiti@2.4.2)

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -1,5 +1,9 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
+import {
+	fixRemoveArrayElement,
+	fixRemoveObjectProperty,
+} from "eslint-fix-utils";
 import * as ESTree from "estree";
 
 import { createRule, PackageJsonRuleContext } from "../createRule";
@@ -52,29 +56,17 @@ const report = (
 		node: node as unknown as ESTree.Node,
 		suggest: [
 			{
-				*fix(fixer) {
-					yield fixer.remove(node as unknown as ESTree.Node);
-
-					const tokenFromCurrentLine =
-						context.sourceCode.getTokenAfter(
-							node as unknown as ESTree.Node,
-						);
-					const tokenFromPreviousLine =
-						context.sourceCode.getTokenBefore(
-							node as unknown as ESTree.Node,
-						);
-
-					if (
-						tokenFromPreviousLine?.value === "," &&
-						tokenFromCurrentLine?.value !== ","
-					) {
-						yield fixer.remove(tokenFromPreviousLine);
-					}
-
-					if (tokenFromCurrentLine?.value === ",") {
-						yield fixer.remove(tokenFromCurrentLine);
-					}
-				},
+				fix:
+					node.type === "JSONProperty"
+						? fixRemoveObjectProperty(
+								context,
+								node as unknown as ESTree.Property,
+							)
+						: fixRemoveArrayElement(
+								context,
+								node as unknown as ESTree.Expression,
+								node.parent as unknown as ESTree.ArrayExpression,
+							),
 				messageId: "remove",
 			},
 		],

--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -1,3 +1,4 @@
+import { fixRemoveArrayElement } from "eslint-fix-utils";
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import * as ESTree from "estree";
@@ -58,39 +59,11 @@ export const rule = createRule({
 					node: element as unknown as ESTree.Node,
 					suggest: [
 						{
-							*fix(fixer) {
-								yield fixer.remove(
-									element as unknown as ESTree.Node,
-								);
-
-								// If this is not the last entry, then we need to remove the comma from this line.
-								const tokenFromCurrentLine =
-									context.sourceCode.getTokenAfter(
-										element as unknown as ESTree.Node,
-									);
-								if (tokenFromCurrentLine?.value === ",") {
-									yield fixer.remove(tokenFromCurrentLine);
-								}
-
-								// If this is the last line and it's not the only entry, then the line above this one
-								// will become the last line, and should not have a trailing comma.
-								if (
-									index > 0 &&
-									tokenFromCurrentLine?.value !== ","
-								) {
-									const tokenFromPreviousLine =
-										context.sourceCode.getTokenAfter(
-											elements[
-												index - 1
-											] as unknown as ESTree.Node,
-										);
-									if (tokenFromPreviousLine?.value === ",") {
-										yield fixer.remove(
-											tokenFromPreviousLine,
-										);
-									}
-								}
-							},
+							fix: fixRemoveArrayElement(
+								context,
+								index,
+								elements as unknown as ESTree.Expression[],
+							),
 							messageId: "remove",
 						},
 					],

--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -1,6 +1,6 @@
-import { fixRemoveArrayElement } from "eslint-fix-utils";
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
+import { fixRemoveArrayElement } from "eslint-fix-utils";
 import * as ESTree from "estree";
 
 import { createRule } from "../createRule.js";

--- a/src/rules/unique-dependencies.ts
+++ b/src/rules/unique-dependencies.ts
@@ -57,7 +57,7 @@ export const rule = createRule({
 									: fixRemoveArrayElement(
 											context,
 											removal as unknown as ESTree.Expression,
-											elements as unknown as (ESTree.Expression | null)[],
+											elements as unknown as ESTree.ArrayExpression,
 										),
 							messageId: "remove",
 						},

--- a/src/rules/unique-dependencies.ts
+++ b/src/rules/unique-dependencies.ts
@@ -1,9 +1,9 @@
+import type { AST as JsonAST } from "jsonc-eslint-parser";
+
 import {
 	fixRemoveArrayElement,
 	fixRemoveObjectProperty,
 } from "eslint-fix-utils";
-import type { AST as JsonAST } from "jsonc-eslint-parser";
-
 import * as ESTree from "estree";
 
 import { createRule } from "../createRule.js";
@@ -85,6 +85,7 @@ export const rule = createRule({
 							node.value.properties.map(
 								(property) => property.key,
 							),
+							// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 							(property) => property.parent!,
 						);
 						break;

--- a/src/tests/rules/no-empty-fields.test.ts
+++ b/src/tests/rules/no-empty-fields.test.ts
@@ -30,6 +30,7 @@ ruleTester.run("no-empty-fields", rule, {
 					],
 				},
 			],
+			only: true,
 		},
 		{
 			code: `{

--- a/src/tests/rules/no-empty-fields.test.ts
+++ b/src/tests/rules/no-empty-fields.test.ts
@@ -30,7 +30,6 @@ ruleTester.run("no-empty-fields", rule, {
 					],
 				},
 			],
-			only: true,
 		},
 		{
 			code: `{


### PR DESCRIPTION
## PR Checklist

-   [x] Addresses an existing open issue: fixes #747
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Uses the exported APIs added in https://github.com/JoshuaKGoldberg/eslint-fix-utils/commit/6bf5c3329eb47c43d38128328fd4501277b3c8ad.

@michaelfaith I'd love to get your input on this: how does the API feel to you? If you think they should be changed drastically -here and/or in the other repo- I'm definitely up for iterating on them. 🙂 

~~The build failures can be ignored, they're some problem in `eslint-fix-utils` that I haven't dug into yet.~~ ~~Blocked on: https://github.com/JoshuaKGoldberg/eslint-fix-utils/issues/7~~ ✅ `eslint-fix-utils@0.2.0` should work now.

💖 