### PR TITLE
ci: update release config to hide non-user-facing categories

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -12,7 +12,19 @@
 	"plugins": {
 		"@release-it/conventional-changelog": {
 			"infile": "CHANGELOG.md",
-			"preset": "angular"
+			"preset": "angular",
+			"types": [
+				{ "section": "Features", "type": "feat" },
+				{ "section": "Bug Fixes", "type": "fix" },
+				{ "section": "Performance Improvements", "type": "perf" },
+				{ "hidden": true, "type": "build" },
+				{ "hidden": true, "type": "chore" },
+				{ "hidden": true, "type": "ci" },
+				{ "hidden": true, "type": "docs" },
+				{ "hidden": true, "type": "refactor" },
+				{ "hidden": true, "type": "style" },
+				{ "hidden": true, "type": "test" }
+			]
 		}
 	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change backports this update to CTA: https://github.com/JoshuaKGoldberg/create-typescript-app/pull/1810  reducing the categories that release-it shows in changelog updates.
