### PR TITLE
fix(no-redundant-files): detect variations of README.md as redundant

### DIFF
--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -7,14 +7,10 @@ import { isJSONStringLiteral, isNotNullish } from "../utils/predicates.js";
 
 const defaultFiles = [
 	/* cspell:disable-next-line */
-	"LICENCE",
-	/* cspell:disable-next-line */
-	"LICENCE.md",
-	"LICENSE",
-	"LICENSE.md",
-	"package.json",
-	"README.md",
-] as const;
+	/^(\.\/)?LICEN(C|S)E(\.|$)/i,
+	/^(\.\/)?README(\.|$)/i,
+	/^(\.\/)?package\.json$/i,
+];
 
 const cachedRegex = new Map<string, RegExp>();
 const getCachedLocalFileRegex = (filename: string) => {
@@ -143,11 +139,8 @@ export const rule = createRule({
 
 							// We can also go ahead and check if this matches one
 							// of the static default files
-							const regex = getCachedLocalFileRegex(
-								element.value,
-							);
 							for (const defaultFile of defaultFiles) {
-								if (regex.test(defaultFile)) {
+								if (defaultFile.test(element.value)) {
 									report(
 										elements,
 										index,

--- a/src/tests/rules/no-redundant-files.test.ts
+++ b/src/tests/rules/no-redundant-files.test.ts
@@ -51,6 +51,51 @@ ruleTester.run("no-redundant-files", rule, {
 		{
 			code: `{
 \t"files": [
+\t\t"README.a-b-c.md",
+\t\t"./package.json"
+    ]
+}
+`,
+			errors: [
+				{
+					data: { file: "README.a-b-c.md" },
+					line: 3,
+					messageId: "unnecessaryDefault",
+					suggestions: [
+						{
+							messageId: "remove",
+							output: `{
+\t"files": [
+\t\t
+\t\t"./package.json"
+    ]
+}
+`,
+						},
+					],
+				},
+				{
+					data: { file: "./package.json" },
+					line: 4,
+					messageId: "unnecessaryDefault",
+					suggestions: [
+						{
+							messageId: "remove",
+							output: `{
+\t"files": [
+\t\t"README.a-b-c.md"
+\t\t
+    ]
+}
+`,
+						},
+					],
+				},
+			],
+		},
+		{
+			code: `{
+\t"files": [
 \t\t"CHANGELOG.md",
 \t\t"dist",
 \t\t"CHANGELOG.md"


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #763 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change detects additional variations of `README` and `LICENSE` files.  Apparently, npm will include any `README` followed by any extension (e.g. `README.fi.md`)

Closes #763 
