### PR TITLE
refactor(valid-local-dependency): remove unreachable code

### DIFF
--- a/src/rules/valid-local-dependency.ts
+++ b/src/rules/valid-local-dependency.ts
@@ -19,8 +19,8 @@ export const rule = createRule({
 					Object.entries(devDependencies ?? {}),
 				] as [string, string][][];
 
-				depObjs.forEach((obj) => {
-					obj.forEach(([key, value]) => {
+				for (const obj of depObjs) {
+					for (const [key, value] of obj) {
 						const response = (localPath: RegExp | string) => {
 							const filePath = path.join(
 								context.filename.replace(/package\.json/g, "/"),
@@ -28,17 +28,10 @@ export const rule = createRule({
 								"/package.json",
 							);
 
+							// Attempt to resolve the file path, and if it fails
+							// and throws, then we know it's invalid.
 							try {
-								if (!require.resolve(filePath)) {
-									context.report({
-										data: {
-											package: key,
-											path: value,
-										},
-										messageId: "invalidPath",
-										node: context.sourceCode.ast,
-									});
-								}
+								require.resolve(filePath);
 							} catch {
 								context.report({
 									data: {
@@ -58,8 +51,8 @@ export const rule = createRule({
 						if (value.startsWith("file:")) {
 							response("file:");
 						}
-					});
-				});
+					}
+				}
 			},
 		};
 	},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #118 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change removes an unreachable code block.  `require.resolve` will only return a string, if the file is resolvable, or throw an error if it isn't.  There's never a case in which `require.resolve` would return a falsy value.

Closes #118