### PR TITLE
feat(valid-scripts): add valid-scripts rule (#839)

### DIFF
--- a/docs/rules/valid-scripts.md
+++ b/docs/rules/valid-scripts.md
@@ -1,0 +1,54 @@
+# valid-scripts
+
+💼 This rule is enabled in the ✅ `recommended` config.
+
+<!-- end auto-generated rule header -->
+
+This rule applies two validations to each property in `"scripts"` field:
+
+-   It must be a string rather than any other data type
+-   It should not be empty
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"scripts": null
+}
+```
+
+```json
+{
+	"scripts": {}
+}
+```
+
+```json
+{
+	"scripts": {
+		"test": ""
+	}
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"scripts": {
+		"build": "tsup",
+		"format": "prettier \"**/*\" --ignore-unknown",
+		"lint": "eslint . --max-warnings 0",
+		"lint:eslint-docs": "pnpm update:eslint-docs --check",
+		"lint:knip": "knip",
+		"lint:md": "markdownlint \"**/*.md\" \".github/**/*.md\"",
+		"lint:packages": "pnpm dedupe --check",
+		"lint:spelling": "cspell \"**\" \".github/**/*\"",
+		"prepare": "husky",
+		"should-semantic-release": "should-semantic-release --verbose",
+		"test": "vitest",
+		"tsc": "tsc",
+		"update:eslint-docs": "eslint-doc-generator --rule-doc-title-format name"
+	}
+}
+```

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -13,6 +13,7 @@ import { rule as validLocalDependency } from "./rules/valid-local-dependency.js"
 import { rule as validName } from "./rules/valid-name.js";
 import { rule as validPackageDefinition } from "./rules/valid-package-definition.js";
 import { rule as validRepositoryDirectory } from "./rules/valid-repository-directory.js";
+import { rule as validScripts } from "./rules/valid-scripts.js";
 import { rule as validVersion } from "./rules/valid-version.js";
 
 const require = createRequire(import.meta.url || __filename);
@@ -34,6 +35,7 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	"valid-name": validName,
 	"valid-package-definition": validPackageDefinition,
 	"valid-repository-directory": validRepositoryDirectory,
+	"valid-scripts": validScripts,
 	"valid-version": validVersion,
 
 	/** @deprecated use 'valid-package-definition' instead */

--- a/src/rules/valid-scripts.ts
+++ b/src/rules/valid-scripts.ts
@@ -1,0 +1,69 @@
+import type { AST as JsonAST } from "jsonc-eslint-parser";
+
+import * as ESTree from "estree";
+
+import { createRule } from "../createRule.js";
+
+export const rule = createRule({
+	create(context) {
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=scripts]"(
+				node: JsonAST.JSONProperty,
+			) {
+				const { value } = node;
+				if (value.type !== "JSONObjectExpression") {
+					context.report({
+						messageId: "incorrectTypeScriptsField",
+						node: node.value as unknown as ESTree.Node,
+					});
+					return;
+				}
+				if (value.properties.length === 0) {
+					context.report({
+						messageId: "emptyScriptsField",
+						node: node.value as unknown as ESTree.Node,
+					});
+					return;
+				}
+				for (const prop of value.properties) {
+					const { value } = prop; // key,
+					if (
+						value.type !== "JSONLiteral" ||
+						typeof value.value !== "string"
+					) {
+						context.report({
+							messageId: "incorrectTypeScript",
+							node: node.value as unknown as ESTree.Node,
+						});
+						return;
+					} else if (value.value.length === 0) {
+						context.report({
+							messageId: "emptyScript",
+							node: node.value as unknown as ESTree.Node,
+						});
+						return;
+					}
+				}
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: "Best Practices",
+			description: "Enforce that package scripts are valid commands",
+			recommended: true,
+		},
+		messages: {
+			emptyScript:
+				'values contained in "scripts" object should not be empty',
+			emptyScriptsField: '"scripts" field should not be empty.',
+			incorrectTypeScript:
+				'values contained in "scripts" object should strings',
+			incorrectTypeScriptsField:
+				'"scripts" field should contain an object.',
+		},
+		schema: [],
+		type: "suggestion",
+	},
+});

--- a/src/tests/rules/valid-scripts.test.ts
+++ b/src/tests/rules/valid-scripts.test.ts
@@ -1,0 +1,61 @@
+import { rule } from "../../rules/valid-scripts.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-scripts", rule, {
+	invalid: [
+		{
+			code: `{ "scripts": null }`,
+			errors: [{ messageId: "incorrectTypeScriptsField" }],
+		},
+		{
+			code: `{ "scripts": 123 }`,
+			errors: [{ messageId: "incorrectTypeScriptsField" }],
+		},
+		{
+			code: `{ "scripts": "" }`,
+			errors: [{ messageId: "incorrectTypeScriptsField" }],
+		},
+		{
+			code: `{ "scripts": [] }`,
+			errors: [{ messageId: "incorrectTypeScriptsField" }],
+		},
+		{
+			code: `{ "scripts": "{}" }`,
+			errors: [{ messageId: "incorrectTypeScriptsField" }],
+		},
+		{
+			code: `{ "scripts": {} }`,
+			errors: [{ messageId: "emptyScriptsField" }],
+		},
+		{
+			code: `{ "scripts": {
+  "test": ""
+} }`,
+			errors: [{ messageId: "emptyScript" }],
+		},
+		{
+			code: `{ "scripts": { "test": null }}`,
+			errors: [{ messageId: "incorrectTypeScript" }],
+		},
+		{
+			code: `{ "scripts": { "test": undefined }}`,
+			errors: [{ messageId: "incorrectTypeScript" }],
+		},
+		{
+			code: `{ "scripts": { "test": {} }}`,
+			errors: [{ messageId: "incorrectTypeScript" }],
+		},
+		{
+			code: `{ "scripts": { "test": 678 }}`,
+			errors: [{ messageId: "incorrectTypeScript" }],
+		},
+	],
+	valid: [
+		`{
+  "scripts": {
+    "commitlint": "commitlint --edit",
+    "prepare": "husky"
+  }
+}`,
+	],
+});


### PR DESCRIPTION
This change adds a new `valid-scripts` rule, which is also included in the `recommended` config.

<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [x] Addresses an existing open issue: fixes #839 
-   [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->

:black_heart: 