### PR TITLE
chore: add build pre-step to doc update rule

### DIFF
--- a/.github/workflows/lint-eslint-docs.yml
+++ b/.github/workflows/lint-eslint-docs.yml
@@ -4,7 +4,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/prepare
-      - run: npm run build
       - run: npm run lint:eslint-docs
 
 name: Lint ESLint Docs

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"should-semantic-release": "should-semantic-release --verbose",
 		"test": "vitest",
 		"tsc": "tsc",
-		"update:eslint-docs": "eslint-doc-generator --rule-doc-title-format name"
+		"update:eslint-docs": "pnpm build && eslint-doc-generator --rule-doc-title-format name"
 	},
 	"lint-staged": {
 		"*": "prettier --ignore-unknown --write"


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

-   [ ] Addresses an existing open issue: fixes #000
-   [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
-   [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a build pre-step to the eslint doc update script.  There's never really a case where you'd not want to have a build happen when running the doc update command, and when running locally, it's not super obvious that it's necessary to run a build first.  Baking it into the update script removes that ambiguity.
