### PR TITLE
fix: support jsr package version specifiers

### DIFF
--- a/src/rules/valid-package-definition.ts
+++ b/src/rules/valid-package-definition.ts
@@ -7,7 +7,7 @@ import { createRule } from "../createRule.js";
 // so we disable some other errors here.
 const unusedErrorPatterns = [
 	/^Url not valid/i,
-	/^Invalid version range for .+?: (?:file|npm|workspace):/i,
+	/^Invalid version range for .+?: (?:file|jsr|npm|workspace):/i,
 	/^author field should have name/i,
 ];
 

--- a/src/tests/rules/valid-package-definition.test.ts
+++ b/src/tests/rules/valid-package-definition.test.ts
@@ -73,7 +73,8 @@ ruleTester.run("valid-package-definition", rule, {
   "dependencies": {
     "foo": "npm:bar@^1.0.0",
     "baz": "file:../baz",
-    "bar": "workspace:*"
+    "bar": "workspace:*",
+    "qux": "jsr:quux@^1.0.0"
   }
 }`,
 			filename: "package.json",


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1019
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Added support for package versions with `jsr:*`.