### PR TITLE
feat(valid-package-definition): add ignoreProperties option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/prepare
-      - run: pnpm tsc
+      - run: pnpm typecheck
 
 name: CI
 

--- a/docs/rules/valid-package-def.md
+++ b/docs/rules/valid-package-def.md
@@ -45,6 +45,25 @@ Examples of **correct** code for this rule:
 }
 ```
 
+### Options
+
+Pass an array of top-level package properties to ignore.
+When provided, any errors related to the properties, won't cause the rule to report a violation.
+This can be useful if you're using any of the more granular `valid-*` rules alongside this one.
+That way you're not double-reporting violations.
+
+Example of excluding the bin property:
+
+```json
+{
+	"package-json/valid-bin": "error",
+	"package-json/validate-package-definition": [
+		"error",
+		{ "ignoreProperties": ["bin"] }
+	]
+}
+```
+
 ## When Not To Use It
 
 npm may complain, but it works perfectly with many package files that do not violate spec.

--- a/docs/rules/valid-package-def.md
+++ b/docs/rules/valid-package-def.md
@@ -45,10 +45,12 @@ Examples of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
+
+### `ignoreProperties`
 
 Pass an array of top-level package properties to ignore.
-When provided, any errors related to the properties, won't cause the rule to report a violation.
+When provided, any errors related to the properties won't cause the rule to report a violation.
 This can be useful if you're using any of the more granular `valid-*` rules alongside this one.
 That way you're not double-reporting violations.
 

--- a/docs/rules/valid-package-definition.md
+++ b/docs/rules/valid-package-definition.md
@@ -45,6 +45,24 @@ Examples of **correct** code for this rule:
 }
 ```
 
+### Options
+
+Pass an array of top-level package properties to ignore. When provided, any errors related to the properties, won't cause the rule to report a violation.
+This can be useful if you're using any of the more granular `valid-*` rules alongside this one.
+That way you're not double-reporting violations.
+
+Example of excluding the bin property:
+
+```json
+{
+	"package-json/valid-bin": "error",
+	"package-json/validate-package-definition": [
+		"error",
+		{ "ignoreProperties": ["bin"] }
+	]
+}
+```
+
 ## When Not To Use It
 
 npm may complain, but it works perfectly with many package files that do not violate spec.

--- a/docs/rules/valid-package-definition.md
+++ b/docs/rules/valid-package-definition.md
@@ -47,7 +47,8 @@ Examples of **correct** code for this rule:
 
 ### Options
 
-Pass an array of top-level package properties to ignore. When provided, any errors related to the properties, won't cause the rule to report a violation.
+Pass an array of top-level package properties to ignore.
+When provided, any errors related to the properties, won't cause the rule to report a violation.
 This can be useful if you're using any of the more granular `valid-*` rules alongside this one.
 That way you're not double-reporting violations.
 

--- a/docs/rules/valid-package-definition.md
+++ b/docs/rules/valid-package-definition.md
@@ -45,10 +45,12 @@ Examples of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
+
+### `ignoreProperties`
 
 Pass an array of top-level package properties to ignore.
-When provided, any errors related to the properties, won't cause the rule to report a violation.
+When provided, any errors related to the properties won't cause the rule to report a violation.
 This can be useful if you're using any of the more granular `valid-*` rules alongside this one.
 That way you're not double-reporting violations.
 
@@ -63,6 +65,10 @@ Example of excluding the bin property:
 	]
 }
 ```
+
+For now, the `recommended` config sets `ignoreProperties` to ignore those that are covered by the newer, more granular `valid-*` rules.
+Once all `valid-*` rules are implemented, `valid-package-definition` will be removed from `recommended`.
+See [#850 💬 Discussion: Which require- and valid- rules should be in the recommended config?](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/850) for the list of rules that will be added.
 
 ## When Not To Use It
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"detect-indent": "6.1.0",
 		"detect-newline": "3.1.0",
 		"eslint-fix-utils": "^0.2.0",
-		"package-json-validator": "^0.10.0",
+		"package-json-validator": "~0.13.1",
 		"semver": "^7.5.4",
 		"sort-object-keys": "^1.1.3",
 		"sort-package-json": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"lint:spelling": "cspell \"**\" \".github/**/*\"",
 		"prepare": "husky",
 		"test": "vitest",
-		"tsc": "tsc"
+		"typecheck": "tsc"
 	},
 	"lint-staged": {
 		"*": "prettier --ignore-unknown --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.1(@types/estree@1.0.7)(eslint@9.27.0(jiti@2.4.2))
       package-json-validator:
-        specifier: ^0.10.0
-        version: 0.10.0
+        specifier: ~0.13.1
+        version: 0.13.1
       semver:
         specifier: ^7.5.4
         version: 7.7.1
@@ -3176,8 +3176,8 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-json-validator@0.10.0:
-    resolution: {integrity: sha512-zaPt4x0ZIxA4KYWpPMkbOEhkEDfQdtkCCC1xhnbnYrQV+Kry3zMAxENujgdT6aPA5BJ+FfpncKoNULWc/qjloQ==}
+  package-json-validator@0.13.1:
+    resolution: {integrity: sha512-8wRiZoasU7/w9eTnW2faWuVYwyEASLgGlVJXvSohOBKrLH+Es57JZ6hXLtCf62vLXK4saYGzLR02QC23FKU8Gw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7394,7 +7394,7 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  package-json-validator@0.10.0:
+  package-json-validator@0.13.1:
     dependencies:
       yargs: 17.7.2
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -54,11 +54,19 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	},
 };
 
-const recommendedRules = Object.fromEntries(
-	Object.entries(rules)
-		.filter(([, rule]) => rule.meta.docs?.recommended)
-		.map(([name]) => ["package-json/" + name, "error" as const]),
-);
+const recommendedRules = {
+	...Object.fromEntries(
+		Object.entries(rules)
+			.filter(([, rule]) => rule.meta.docs?.recommended)
+			.map(([name]) => ["package-json/" + name, "error" as const]),
+	),
+	// As we add more `valid-*` rules, we should prevent this legacy rule from
+	// also reporting the same errors.
+	"package-json/valid-package-definition": [
+		"error",
+		{ ignoreProperties: ["name", "version", "bin"] },
+	],
+};
 
 export const plugin = {
 	configs: {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,3 +1,4 @@
+import { ESLint, Linter } from "eslint";
 import * as parserJsonc from "jsonc-eslint-parser";
 import { createRequire } from "node:module";
 
@@ -60,7 +61,7 @@ const baseRecommendedRules = {
 			.filter(([, rule]) => rule.meta.docs?.recommended)
 			.map(([name]) => ["package-json/" + name, "error" as const]),
 	),
-};
+} satisfies Linter.RulesRecord;
 
 const recommendedRules = {
 	...baseRecommendedRules,
@@ -82,7 +83,7 @@ const recommendedRules = {
 				.map(([name]) => name.replace("package-json/valid-", "")),
 		},
 	],
-};
+} satisfies Linter.RulesRecord;
 
 export const plugin = {
 	configs: {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 
 import type { PackageJsonRuleModule } from "./createRule.js";
 
-import { rule as noEmptyFields, rule } from "./rules/no-empty-fields.js";
+import { rule as noEmptyFields } from "./rules/no-empty-fields.js";
 import { rule as noRedundantFiles } from "./rules/no-redundant-files.js";
 import { rule as orderProperties } from "./rules/order-properties.js";
 import { rule as preferRepositoryShorthand } from "./rules/repository-shorthand.js";

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -77,8 +77,7 @@ const recommendedRules = {
 				.filter(
 					([name]) =>
 						name.startsWith("package-json/valid-") &&
-						name !== "package-json/valid-package-definition" &&
-						name !== "package-json/valid-package-def",
+						name !== "package-json/valid-package-definition",
 				)
 				.map(([name]) => name.replace("package-json/valid-", "")),
 		},

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { ESLint, Linter } from "eslint";
+import { Linter } from "eslint";
 import * as parserJsonc from "jsonc-eslint-parser";
 import { createRequire } from "node:module";
 

--- a/src/rules/valid-package-definition.ts
+++ b/src/rules/valid-package-definition.ts
@@ -2,6 +2,11 @@ import { validate } from "package-json-validator";
 
 import { createRule } from "../createRule.js";
 
+interface Option {
+	ignoreProperties?: string[];
+}
+type Options = [Option?];
+
 // package-json-validator does not correctly recognize shorthand for repositories and alternate dependency statements, so we discard those values.
 // it also enforces a stricter code for npm than is really appropriate,
 // so we disable some other errors here.
@@ -14,21 +19,31 @@ const ignoredErrors = [
 const isUsableError = (errorText: string) =>
 	ignoredErrors.every((pattern) => !pattern.test(errorText));
 
-export const rule = createRule({
+export const rule = createRule<Options>({
 	create(context) {
+		const ignoreProperties = context.options[0]?.ignoreProperties ?? [];
+
 		return {
 			"Program:exit"() {
 				const validation = validate(context.sourceCode.text);
 
-				validation.errors?.filter(isUsableError).forEach((message) => {
-					if (message) {
+				const usableErrors =
+					validation.errors?.filter((error) => {
+						return (
+							isUsableError(error.message) &&
+							!ignoreProperties.includes(error.field)
+						);
+					}) ?? [];
+
+				for (const error of usableErrors) {
+					if (error.message) {
 						context.report({
 							// eslint-disable-next-line eslint-plugin/prefer-message-ids
-							message,
+							message: error.message,
 							node: context.sourceCode.ast,
 						});
 					}
-				});
+				}
 			},
 		};
 	},
@@ -41,7 +56,20 @@ export const rule = createRule({
 				"Enforce that package.json has all properties required by the npm spec",
 			recommended: true,
 		},
-		schema: [],
+		schema: [
+			{
+				additionalProperties: false,
+				properties: {
+					ignoreProperties: {
+						items: {
+							type: "string",
+						},
+						type: "array",
+					},
+				},
+				type: "object",
+			},
+		],
 		type: "problem",
 	},
 });

--- a/src/tests/rules/valid-package-definition.test.ts
+++ b/src/tests/rules/valid-package-definition.test.ts
@@ -78,5 +78,14 @@ ruleTester.run("valid-package-definition", rule, {
 }`,
 			filename: "package.json",
 		},
+		{
+			code: `{ "thee-silver": "mt-zion" }`,
+			filename: "packages/nested/package.json",
+			options: [
+				{
+					ignoreProperties: ["name", "version"],
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1076 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `ignoreProperties` option to the `valid-package-definition` rule, allowing you to provide a list of top-level properties to suppress violation reports for.  This can be useful when using this rule alongside any of the more granular `valid-*` rules, so that it's not double reporting violations.
