### PR TITLE
fix: prevent `no-redundant-files` crash with wildcard and `main` field

### DIFF
--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -13,11 +13,11 @@ const defaultFiles = [
 	/^(\.\/)?package\.json$/i,
 ];
 
-const hasWildcards = (filename: string): boolean => /[*?[\]{}]/.test(filename);
+const wildcardsRegex = /[*?[\]{}]/;
 
 const cachedRegex = new Map<string, RegExp>();
 const getCachedLocalFileRegex = (filename: string) => {
-	if (hasWildcards(filename)) {
+	if (wildcardsRegex.test(filename)) {
 		return null;
 	}
 

--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -13,8 +13,14 @@ const defaultFiles = [
 	/^(\.\/)?package\.json$/i,
 ];
 
+const hasWildcards = (filename: string): boolean => /[*?[\]{}]/.test(filename);
+
 const cachedRegex = new Map<string, RegExp>();
 const getCachedLocalFileRegex = (filename: string) => {
+	if (hasWildcards(filename)) {
+		return null;
+	}
+
 	// Strip the leading `./`, if there is one, since we'll be incorporating
 	// it into the regex.
 	const baseFilename = filename.replace("./", "");
@@ -161,7 +167,7 @@ export const rule = createRule({
 								const regex = getCachedLocalFileRegex(
 									fileEntry.value,
 								);
-								if (regex.test(fileToCheck)) {
+								if (regex?.test(fileToCheck)) {
 									report(files, index, validation.messageId);
 								}
 							}

--- a/src/tests/rules/no-redundant-files.test.ts
+++ b/src/tests/rules/no-redundant-files.test.ts
@@ -370,5 +370,49 @@ ruleTester.run("no-redundant-files", rule, {
   "cli": "./bin/cli.js"
 }}`,
 		`{ "main": "./dist/index.js", "files": ["CHANGELOG.md", "dist"] }`,
+		`{
+		"main": "./index.js",
+		"files": [
+			"*.d.ts",
+			"dist"
+		]
+	}`,
+		`{
+		"main": "./lib/index.js",
+		"files": [
+			"lib/**/*.js",
+			"*.d.ts",
+		]
+	}`,
+		`{
+		"bin": "./bin/cli.js",
+		"files": [
+			"bin/*",
+			"*.json"
+		]
+	}`,
+		`{
+		"files": [
+			"src/**/*",
+			"*.ts",
+			"!src/**/*.test.ts"
+		]
+	}`,
+		`{
+		"files": [
+			"**/*.d.ts",
+			"lib/[abc].js",
+			"src/{utils,helpers}/*.js"
+		]
+	}`,
+
+		`{
+		"main": "./index.js", 
+		"files": [
+			"*.d.ts",
+			"dist/specific-file.js",
+			"lib/**/*"
+		]
+	}`,
 	],
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1066
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixed a crash in the `no-redundant-files` rule when `files` contains wildcard patterns (like `*.d.ts`) and a `main` field is present.

- Added wildcard detection to `getCachedLocalFileRegex` function
- Files with glob patterns (`*`, `?`, `[]`, `{}`, `**`, `!`) are now skipped during validation
- Regular files continue to be validated normally for redundancy
- Added comprehensive test coverage for wildcard patterns

The rule now gracefully handles package.json files with glob patterns while maintaining all existing validation for regular file paths.
