### PR TITLE
feat(valid-bin): add new rule for validating bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [restrict-dependency-ranges](docs/rules/restrict-dependency-ranges.md) | Restricts the range of dependencies to allow or disallow specific types of ranges.                |      |    | 💡 |    |
 | [sort-collections](docs/rules/sort-collections.md)                     | Dependencies, scripts, and configuration values must be declared in alphabetical order.           | ✔️ ✅ | 🔧 |    |    |
 | [unique-dependencies](docs/rules/unique-dependencies.md)               | Checks a dependency isn't specified more than once (i.e. in `dependencies` and `devDependencies`) | ✔️ ✅ |    | 💡 |    |
+| [valid-bin](docs/rules/valid-bin.md)                                   | Enforce that the `bin` property is valid.                                                         | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        | ✔️ ✅ |    |    |    |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |
 | [valid-package-def](docs/rules/valid-package-def.md)                   | Enforce that package.json has all properties required by the npm spec                             |      |    |    | ❌  |

--- a/docs/rules/valid-bin.md
+++ b/docs/rules/valid-bin.md
@@ -1,0 +1,36 @@
+# valid-bin
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+This rule does the following checks on value of the `bin` property:
+
+- It must be either a non-empty string or an object.
+- If the value is an object, it should only consist of non-empty string values
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"bin": {
+		"invalid-bin": 123
+	}
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"bin": "./bin/cli.mjs"
+}
+```
+
+```json
+{
+	"bin": {
+		"my-cli": "./bin/cli.mjs"
+	}
+}
+```

--- a/docs/rules/valid-name.md
+++ b/docs/rules/valid-name.md
@@ -4,7 +4,7 @@
 
 <!-- end auto-generated rule header -->
 
-This rule applies two validations to the `"name"` property:
+This rule applies two validations to the `name` property:
 
 - It must be a string rather than any other data type
 - It should pass [`validate-npm-package-name`](https://www.npmjs.com/package/validate-npm-package-name) validation

--- a/docs/rules/valid-version.md
+++ b/docs/rules/valid-version.md
@@ -4,7 +4,7 @@
 
 <!-- end auto-generated rule header -->
 
-This rule applies two validations to the `"name"` property:
+This rule applies two validations to the `version` property:
 
 - It must be a string rather than any other data type
 - It should pass [`semver`](https://www.npmjs.com/package/semver) validation

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -12,6 +12,7 @@ import { rules as requireRules } from "./rules/require-properties.js";
 import { rule as restrictDependencyRanges } from "./rules/restrict-dependency-ranges.js";
 import { rule as sortCollections } from "./rules/sort-collections.js";
 import { rule as uniqueDependencies } from "./rules/unique-dependencies.js";
+import { rule as validBin } from "./rules/valid-bin.js";
 import { rule as validLocalDependency } from "./rules/valid-local-dependency.js";
 import { rule as validName } from "./rules/valid-name.js";
 import { rule as validPackageDefinition } from "./rules/valid-package-definition.js";
@@ -34,6 +35,7 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	"restrict-dependency-ranges": restrictDependencyRanges,
 	"sort-collections": sortCollections,
 	"unique-dependencies": uniqueDependencies,
+	"valid-bin": validBin,
 	"valid-local-dependency": validLocalDependency,
 	"valid-name": validName,
 	"valid-package-definition": validPackageDefinition,

--- a/src/rules/valid-bin.ts
+++ b/src/rules/valid-bin.ts
@@ -1,0 +1,46 @@
+import * as ESTree from "estree";
+import { AST as JsonAST } from "jsonc-eslint-parser";
+import { validateBin } from "package-json-validator";
+
+import { createRule } from "../createRule.js";
+
+export const rule = createRule({
+	create(context) {
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=bin]"(
+				node: JsonAST.JSONProperty,
+			) {
+				const binValueNode = node.value as unknown as ESTree.Node;
+				const binValue: unknown = JSON.parse(
+					context.sourceCode.getText(binValueNode),
+				);
+
+				const errors = validateBin(binValue);
+				if (!errors.length) {
+					return;
+				}
+
+				context.report({
+					data: {
+						errors: errors.join("\n             "),
+					},
+					messageId: "validationError",
+					node: binValueNode,
+				});
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: "Best Practices",
+			description: "Enforce that the `bin` property is valid.",
+			recommended: true,
+		},
+		messages: {
+			validationError: "Invalid bin: {{ errors }}",
+		},
+		schema: [],
+		type: "problem",
+	},
+});

--- a/src/rules/valid-bin.ts
+++ b/src/rules/valid-bin.ts
@@ -22,7 +22,10 @@ export const rule = createRule({
 
 				context.report({
 					data: {
-						errors: errors.join("\n             "),
+						errors:
+							errors.length > 1
+								? ["", ...errors].join("\n - ")
+								: errors[0],
 					},
 					messageId: "validationError",
 					node: binValueNode,

--- a/src/tests/rules/valid-bin.test.ts
+++ b/src/tests/rules/valid-bin.test.ts
@@ -1,0 +1,99 @@
+import { rule } from "../../rules/valid-bin.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-bin", rule, {
+	invalid: [
+		{
+			code: `{
+	"bin": null
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "bin field is `null`, but should be a `string` or an `object`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"bin": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: 'Type for field "bin" should be `string` or `object`, not `number`',
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"bin": ""
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "bin field is empty, but should be a relative path",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"bin": { "invalid-bin": 123 }
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: 'bin field "invalid-bin" should be a string',
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"bin": { "invalid-bin": "" }
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: 'bin field "invalid-bin" is empty, but should be a relative path',
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"bin": { "": "invalid-key" }
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "bin field 0 has an empty key, but should be a valid command name",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		`{ "bin": "./silver-mt-zion.js" }`,
+		`{ "bin": "silver-mt-zion.js" }`,
+		`{ "bin": { "silver-mt-zion": "./silver-mt-zion.js" } }`,
+		`{ "bin": { "silver-mt-zion": "silver-mt-zion.js" } }`,
+		`{ "bin": { "silver-mt-zion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
+	],
+});

--- a/src/tests/rules/valid-bin.test.ts
+++ b/src/tests/rules/valid-bin.test.ts
@@ -87,6 +87,22 @@ ruleTester.run("valid-bin", rule, {
 				},
 			],
 		},
+		{
+			code: `{
+	"bin": { "": "invalid-key", "   ": "invalid-key" }
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: `
+ - bin field 0 has an empty key, but should be a valid command name
+ - bin field 1 has an empty key, but should be a valid command name`,
+					},
+					messageId: "validationError",
+				},
+			],
+		},
 	],
 	valid: [
 		"{}",


### PR DESCRIPTION

## PR Checklist

- [x] Addresses an existing open issue: fixes #818 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `valid-bin` rule that uses `validateBin` from `package-json-validator` to identify errors.

This will need to wait to merge after #1077, so that we're not double-reporting validation errors on `bin` with `valid-package-definition`.

Lastly, this is the first new rule that employs our new approach of using the more granular validation functions from `package-json-validator` and can serve as a model for the rest of the `valid-*` rules.
