### PR TITLE
chore: correct author attribution and reset cspell words

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -9,29 +9,5 @@
 		"node_modules",
 		"pnpm-lock.yaml"
 	],
-	"words": [
-		"Codecov",
-		"altano",
-		"autofixable",
-		"codespace",
-		"commitlint",
-		"contributorsrc",
-		"conventionalcommits",
-		"eslint-doc-generatorrc",
-		"estree",
-		"knip",
-		"lcov",
-		"markdownlintignore",
-		"npmpackagejsonlintrc",
-		"outro",
-		"packagejson",
-		"postbuild",
-		"postwatch",
-		"quickstart",
-		"ruleset",
-		"tsup",
-		"wontfix",
-		"zetlan",
-		"zetlen"
-	]
+	"words": ["altano", "generatorrc", "postbuild", "postwatch", "zetlen"]
 }

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
 	},
 	"license": "MIT",
 	"author": {
-		"name": "James Zetlan",
-		"email": "zetlan@gmail.com"
+		"name": "James Zetlen",
+		"email": "zetlen@gmail.com"
 	},
 	"type": "commonjs",
 	"exports": {


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #1104 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Correcting the `package.json` `author` also removed the excess `zetlan` from the `cspell.json` `words`. I removed a bunch more by:

1. Deleting it
2. Running `npx cspell-populate-words "**" ".github/**"`

🗂️