### PR TITLE
feat(valid-bin): add option for enforcing kebab-case

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [sort-collections](docs/rules/sort-collections.md)                     | Dependencies, scripts, and configuration values must be declared in alphabetical order.           | ✔️ ✅ | 🔧 |    |    |
 | [unique-dependencies](docs/rules/unique-dependencies.md)               | Checks a dependency isn't specified more than once (i.e. in `dependencies` and `devDependencies`) | ✔️ ✅ |    | 💡 |    |
 | [valid-author](docs/rules/valid-author.md)                             | Enforce that the author field is a valid npm author specification                                 | ✔️ ✅ |    |    |    |
-| [valid-bin](docs/rules/valid-bin.md)                                   | Enforce that the `bin` property is valid.                                                         | ✔️ ✅ |    |    |    |
+| [valid-bin](docs/rules/valid-bin.md)                                   | Enforce that the `bin` property is valid.                                                         | ✔️ ✅ |    | 💡 |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        |      |    |    | ❌  |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |
 | [valid-package-def](docs/rules/valid-package-def.md)                   | Enforce that package.json has all properties required by the npm spec                             |      |    |    | ❌  |

--- a/docs/rules/valid-bin.md
+++ b/docs/rules/valid-bin.md
@@ -2,6 +2,8 @@
 
 💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
 
+💡 This rule is manually fixable by [editor suggestions](https://eslint.org/docs/latest/use/core-concepts#rule-suggestions).
+
 <!-- end auto-generated rule header -->
 
 This rule does the following checks on value of the `bin` property:
@@ -23,14 +25,57 @@ Example of **correct** code for this rule:
 
 ```json
 {
-	"bin": "./bin/cli.mjs"
+	"bin": "./bin/cli.js"
 }
 ```
 
 ```json
 {
 	"bin": {
-		"my-cli": "./bin/cli.mjs"
+		"my-cli": "./bin/cli.js"
+	}
+}
+```
+
+## Options
+
+### enforceCase
+
+If set to true, the rule will enforce that when your `bin` value is an object, its keys (representing the commands for each script) should be in [kebab case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (e.g. `my-command`).
+
+#### Example
+
+Given the following config
+
+```ts
+export default [
+	{
+		"package-json/valid-bin": [
+			"error",
+			{
+				enforceCase: true,
+			},
+		],
+	},
+];
+```
+
+Example of **incorrect** code:
+
+```json
+{
+	"bin": {
+		"invalidCommand": "./bin/cli.js"
+	}
+}
+```
+
+Example of **correct** code:
+
+```json
+{
+	"bin": {
+		"valid-command": "./bin/cli.js"
 	}
 }
 ```

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 	},
 	"dependencies": {
 		"@altano/repository-tools": "^1.0.0",
+		"change-case": "^5.4.4",
 		"detect-indent": "7.0.1",
 		"detect-newline": "4.0.1",
 		"eslint-fix-utils": "^0.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@altano/repository-tools':
         specifier: ^1.0.0
         version: 1.0.1
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       detect-indent:
         specifier: 7.0.1
         version: 7.0.1

--- a/src/tests/rules/valid-bin.test.ts
+++ b/src/tests/rules/valid-bin.test.ts
@@ -103,6 +103,51 @@ ruleTester.run("valid-bin", rule, {
 				},
 			],
 		},
+		{
+			code: `{
+				"bin": {
+					"silverMtZion": "silver-mt-zion.js",
+                    "NIN": "./nin.js"
+                }
+            }`,
+			errors: [
+				{
+					data: {
+						property: "silverMtZion",
+					},
+					messageId: "invalidCase",
+					suggestions: [
+						{
+							messageId: "convertToKebabCase",
+							output: `{
+				"bin": {
+					"silver-mt-zion": "silver-mt-zion.js",
+                    "NIN": "./nin.js"
+                }
+            }`,
+						},
+					],
+				},
+				{
+					data: {
+						property: "NIN",
+					},
+					messageId: "invalidCase",
+					suggestions: [
+						{
+							messageId: "convertToKebabCase",
+							output: `{
+				"bin": {
+					"silverMtZion": "silver-mt-zion.js",
+                    "nin": "./nin.js"
+                }
+            }`,
+						},
+					],
+				},
+			],
+			options: [{ enforceCase: true }],
+		},
 	],
 	valid: [
 		"{}",
@@ -111,5 +156,10 @@ ruleTester.run("valid-bin", rule, {
 		`{ "bin": { "silver-mt-zion": "./silver-mt-zion.js" } }`,
 		`{ "bin": { "silver-mt-zion": "silver-mt-zion.js" } }`,
 		`{ "bin": { "silver-mt-zion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
+		`{ "bin": { "silverMtZion": "silver-mt-zion.js", "NIN": "./nin.js" } }`,
+		{
+			code: `{ "bin": { "silver-mt-zion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
+			options: [{ enforceCase: true }],
+		},
 	],
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1081
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new option to the `valid-bin` rule, that enforces that, when the `bin` value is an object, the keys of the object (representing the commands for each script) are formatted as kebab-case.   Violations for this include editor suggestions for converting the key to kebab case.
