### PR TITLE
refactor: augment estree module

### DIFF
--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -53,7 +53,7 @@ const report = (
 	context.report({
 		data,
 		messageId,
-		node: node as unknown as ESTree.Node,
+		node,
 		suggest: [
 			{
 				fix:

--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -55,7 +55,7 @@ export const rule = createRule({
 				context.report({
 					data: { file: element.value },
 					messageId,
-					node: element as unknown as ESTree.Node,
+					node: element,
 					suggest: [
 						{
 							fix: fixRemoveArrayElement(

--- a/src/rules/repository-shorthand.ts
+++ b/src/rules/repository-shorthand.ts
@@ -1,5 +1,3 @@
-import type ESTree from "estree";
-
 import { JSONProperty } from "jsonc-eslint-parser/lib/parser/ast.js";
 
 import { createRule } from "../createRule.js";
@@ -35,7 +33,7 @@ export const rule = createRule<Options>({
 						}
 
 						return fixer.replaceText(
-							node.value as unknown as ESTree.Node,
+							node.value,
 							JSON.stringify(
 								{
 									type: "git",
@@ -47,7 +45,7 @@ export const rule = createRule<Options>({
 						);
 					},
 					messageId: "preferObject",
-					node: node.value as unknown as ESTree.Node,
+					node: node.value,
 				});
 			}
 		}
@@ -59,12 +57,12 @@ export const rule = createRule<Options>({
 					context.report({
 						fix(fixer) {
 							return fixer.replaceText(
-								node.value as unknown as ESTree.Node,
+								node.value,
 								JSON.stringify(cleanGitHubUrl(value)),
 							);
 						},
 						messageId: "preferShorthand",
-						node: node.value as unknown as ESTree.Node,
+						node: node.value,
 					});
 				}
 
@@ -103,12 +101,12 @@ export const rule = createRule<Options>({
 			context.report({
 				fix(fixer) {
 					return fixer.replaceText(
-						node.value as unknown as ESTree.Node,
+						node.value,
 						JSON.stringify(cleanGitHubUrl(url)),
 					);
 				},
 				messageId: "preferShorthand",
-				node: node.value as unknown as ESTree.Node,
+				node: node.value,
 			});
 		}
 

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -1,6 +1,5 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
-import * as ESTree from "estree";
 import semver from "semver";
 
 import { createRule } from "../createRule.js";
@@ -220,7 +219,7 @@ export const rule = createRule<Options>({
 									rangeTypes: rangeTypes.join(", "),
 								},
 								messageId: "wrongRangeType",
-								node: property.value as unknown as ESTree.Node,
+								node: property.value,
 							});
 							break;
 						}
@@ -243,7 +242,7 @@ export const rule = createRule<Options>({
 									rangeTypes: rangeTypes.join(", "),
 								},
 								messageId: "wrongRangeType",
-								node: property.value as unknown as ESTree.Node,
+								node: property.value,
 								suggest: rangeTypes.map((rangeType) => ({
 									fix(fixer) {
 										return fixer.replaceText(

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -1,7 +1,5 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
-import * as ESTree from "estree";
-
 import { createRule } from "../createRule.js";
 
 const defaultCollections = new Set([
@@ -119,7 +117,7 @@ export const rule = createRule<Options>({
 						},
 						fix(fixer) {
 							return fixer.replaceText(
-								collection as unknown as ESTree.Node,
+								collection,
 								JSON.stringify(
 									desiredOrder.reduce<
 										Record<string, unknown>
@@ -130,7 +128,7 @@ export const rule = createRule<Options>({
 											).value
 										] = JSON.parse(
 											context.sourceCode.getText(
-												property.value as unknown as ESTree.Node,
+												property.value,
 											),
 										);
 										return out;
@@ -144,7 +142,7 @@ export const rule = createRule<Options>({
 						},
 						loc: collection.loc,
 						messageId: "notAlphabetized",
-						node: node as unknown as ESTree.Node,
+						node,
 					});
 				}
 			},

--- a/src/rules/unique-dependencies.ts
+++ b/src/rules/unique-dependencies.ts
@@ -45,7 +45,7 @@ export const rule = createRule({
 				const removal = getNodeToRemove(node);
 				context.report({
 					messageId: "overridden",
-					node: node as unknown as ESTree.Node,
+					node,
 					suggest: [
 						{
 							fix:

--- a/src/rules/valid-author.ts
+++ b/src/rules/valid-author.ts
@@ -1,6 +1,5 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
-import * as ESTree from "estree";
 import { validateAuthor } from "package-json-validator";
 
 import { createRule } from "../createRule.js";
@@ -13,9 +12,7 @@ export const rule = createRule({
 				node: JsonAST.JSONProperty,
 			) {
 				const authorValue: unknown = JSON.parse(
-					context.sourceCode.getText(
-						node.value as unknown as ESTree.Node,
-					),
+					context.sourceCode.getText(node.value),
 				);
 
 				const errors = validateAuthor(authorValue);
@@ -26,7 +23,7 @@ export const rule = createRule({
 							errors: formatErrors(errors),
 						},
 						messageId: "invalid",
-						node: node.value as unknown as ESTree.Node,
+						node: node.value,
 					});
 				}
 			},

--- a/src/rules/valid-bin.ts
+++ b/src/rules/valid-bin.ts
@@ -1,5 +1,4 @@
 import { kebabCase } from "change-case";
-import * as ESTree from "estree";
 import { AST as JsonAST } from "jsonc-eslint-parser";
 import { validateBin } from "package-json-validator";
 
@@ -16,7 +15,7 @@ export const rule = createRule<Options>({
 			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=bin]"(
 				node: JsonAST.JSONProperty,
 			) {
-				const binValueNode = node.value as unknown as ESTree.Node;
+				const binValueNode = node.value;
 				const binValue: unknown = JSON.parse(
 					context.sourceCode.getText(binValueNode),
 				);

--- a/src/rules/valid-name.ts
+++ b/src/rules/valid-name.ts
@@ -1,6 +1,5 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
-import * as ESTree from "estree";
 import validate from "validate-npm-package-name";
 
 import { createRule } from "../createRule.js";
@@ -17,7 +16,7 @@ export const rule = createRule({
 				) {
 					context.report({
 						messageId: "type",
-						node: node.value as unknown as ESTree.Node,
+						node: node.value,
 					});
 					return;
 				}
@@ -49,7 +48,7 @@ export const rule = createRule({
 							.join("; "),
 					},
 					messageId: "invalid",
-					node: node.value as unknown as ESTree.Node,
+					node: node.value,
 				});
 			},
 		};

--- a/src/rules/valid-repository-directory.ts
+++ b/src/rules/valid-repository-directory.ts
@@ -1,7 +1,6 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import { findRootSync } from "@altano/repository-tools";
-import * as ESTree from "estree";
 import * as path from "node:path";
 
 import { createRule } from "../createRule.js";
@@ -81,7 +80,7 @@ export const rule = createRule({
 					) {
 						context.report({
 							messageId: "mismatched",
-							node: directoryProperty.value as unknown as ESTree.Node,
+							node: directoryProperty.value,
 						});
 					}
 				} else {
@@ -108,13 +107,13 @@ export const rule = createRule({
 					if (expected !== directoryValue) {
 						context.report({
 							messageId: "mismatched",
-							node: directoryProperty.value as unknown as ESTree.Node,
+							node: directoryProperty.value,
 							suggest: [
 								{
 									data: { expected },
 									fix(fixer) {
 										return fixer.replaceText(
-											directoryProperty.value as unknown as ESTree.Node,
+											directoryProperty.value,
 											`"${expected}"`,
 										);
 									},

--- a/src/rules/valid-version.ts
+++ b/src/rules/valid-version.ts
@@ -1,6 +1,5 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
-import * as ESTree from "estree";
 import semver from "semver";
 
 import { createRule } from "../createRule.js";
@@ -17,7 +16,7 @@ export const rule = createRule({
 				) {
 					context.report({
 						messageId: "type",
-						node: node.value as unknown as ESTree.Node,
+						node: node.value,
 					});
 					return;
 				}
@@ -25,7 +24,7 @@ export const rule = createRule({
 				if (!semver.valid(node.value.value)) {
 					context.report({
 						messageId: "invalid",
-						node: node.value as unknown as ESTree.Node,
+						node: node.value,
 					});
 				}
 			},

--- a/src/types/estree.d.ts
+++ b/src/types/estree.d.ts
@@ -1,0 +1,7 @@
+import { JSONNode } from "jsonc-eslint-parser";
+
+declare module "estree" {
+	interface NodeMap {
+		JSONNode: JSONNode;
+	}
+}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #125
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds the `JSONNode` to `estree`'s `NodeMap`, so that we don't have to clumsily caste AST types from `jsonc-eslint-parser` to `estree` types.  Really, this is something that `jsonc-eslint-parser` should be doing on their side...

Note: we still have to do some clumsy casting for things we pass into the `eslint-fix-utils` functions.  So there could improvements we might need to make on that side.