### PR TITLE
ci: run tests on all supported node versions

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -2,13 +2,19 @@ description: Prepares the repo for a typical CI job
 
 name: Prepare
 
+inputs:
+  node-version:
+    description: "Node.js version to use"
+    default: "20"
+    required: false
+
 runs:
   steps:
     - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
     - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         cache: pnpm
-        node-version: 20
+        node-version: ${{ inputs.node-version }}
     - run: pnpm install --frozen-lockfile
       shell: bash
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,11 @@
+name: CI
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main
+
 jobs:
   build:
     name: Build
@@ -58,11 +66,20 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm format --list-different
   test:
-    name: Test
+    name: Test (Node.js ${{ matrix.node-version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 24
+          - 22
+          - 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/prepare
+        with:
+          node-version: ${{ matrix.node-version }}
       - run: pnpm run test --coverage
       - env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -75,11 +92,3 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/prepare
       - run: pnpm typecheck
-
-name: CI
-
-on:
-  pull_request: ~
-  push:
-    branches:
-      - main


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates our ci workflow to run the test stage in CI against node 20, 22, and 24.  This ensures that all supported versions of node work as expected.
