### PR TITLE
docs: define deprecation policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Once the RFC period is over, if the removal is still moving forward, the API(s) 
 ### Removal Timeframe (6 months)
 
 Once an API has been marked as deprecated, it will remain intact for at least 6 months.
-After 6 months from the date of deprecation, the API is subject for removal.
+After 6 months from the date of deprecation, the API is subject to removal.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,25 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 These rules only run on `package.json` files; they will ignore all other files being linted.
 They can lint `package.json` files at project root and in any subfolder of the project, making this plugin great for monorepos.
 
+## Deprecation Policy
+
+We never _want_ to remove things, when we're building them!
+But the reality is that libraries evolve and deprecations are a fact of life.
+Following are the different timeframes that we've defined as it relates to deprecating APIs in this project.
+
+### RFC Timeframe (6 weeks)
+
+When some aspect of our API is going to be deprecated (and eventually removed), it must initially go through an RFC phase.
+Whoever's motivating the removal of the api, should create an RFC issue explaining the proposal and inviting feedback from the community.
+That RFC should remain active for at least 6 weeks.
+The RFC text should make clear what the target date is for closing the RFC.
+Once the RFC period is over, if the removal is still moving forward, the API(s) should be officially deprecated.
+
+### Removal Timeframe (6 months)
+
+Once an API has been marked as deprecated, it will remain intact for at least 6 months.
+After 6 months from the date of deprecation, the API is subject for removal.
+
 ## Development
 
 See [`.github/CONTRIBUTING.md`](./.github/CONTRIBUTING.md), then [`.github/DEVELOPMENT.md`](./.github/DEVELOPMENT.md).


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1119
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a "Deprecation Policy" section to our README.

@JoshuaKGoldberg recommended also including an RFC / Consideration period (https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/1119#issuecomment-3000597078), which I've incorporated.  He'd thrown out the idea of 3 months.  That felt a little long for an RFC period.  I generally see RFCs wrapping up within a month or two.  I put it at 6 weeks (which felt good against 6 month removal period).  But happy to go with something in the middle.  Let me know what you think.
