### PR TITLE
feat(valid-bundleDependencies): add new rule for validating `bundleDependencies`

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [unique-dependencies](docs/rules/unique-dependencies.md)               | Checks a dependency isn't specified more than once (i.e. in `dependencies` and `devDependencies`) | ✔️ ✅ |    | 💡 |    |
 | [valid-author](docs/rules/valid-author.md)                             | Enforce that the author field is a valid npm author specification                                 | ✔️ ✅ |    |    |    |
 | [valid-bin](docs/rules/valid-bin.md)                                   | Enforce that the `bin` property is valid.                                                         | ✔️ ✅ |    | 💡 |    |
+| [valid-bundleDependencies](docs/rules/valid-bundleDependencies.md)     | Enforce that the `bundleDependencies` (or `bundledDependencies`) property is valid.               | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        |      |    |    | ❌  |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |
 | [valid-package-definition](docs/rules/valid-package-definition.md)     | Enforce that package.json has all properties required by the npm spec                             | ✔️ ✅ |    |    |    |

--- a/docs/rules/valid-bundleDependencies.md
+++ b/docs/rules/valid-bundleDependencies.md
@@ -1,0 +1,32 @@
+# valid-bundleDependencies
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+This rule does the following checks on the value of the `bundleDependencies` property, as well as the its alias `bundledDependencies`:
+
+- It must be either an array or a boolean.
+- If the value is an array, it should only consist of non-empty strings
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"bundleDependencies": [123]
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"bundleDependencies": ["valid-dependency"]
+}
+```
+
+```json
+{
+	"bundleDependencies": true
+}
+```

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -14,6 +14,7 @@ import { rule as sortCollections } from "./rules/sort-collections.js";
 import { rule as uniqueDependencies } from "./rules/unique-dependencies.js";
 import { rule as validAuthor } from "./rules/valid-author.js";
 import { rule as validBin } from "./rules/valid-bin.js";
+import { rule as validBundleDependencies } from "./rules/valid-bundleDependencies.js";
 import { rule as validLocalDependency } from "./rules/valid-local-dependency.js";
 import { rule as validName } from "./rules/valid-name.js";
 import { rule as validPackageDefinition } from "./rules/valid-package-definition.js";
@@ -40,6 +41,7 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	"unique-dependencies": uniqueDependencies,
 	"valid-author": validAuthor,
 	"valid-bin": validBin,
+	"valid-bundleDependencies": validBundleDependencies,
 	"valid-local-dependency": validLocalDependency,
 	"valid-name": validName,
 	"valid-package-definition": validPackageDefinition,

--- a/src/rules/valid-bundleDependencies.ts
+++ b/src/rules/valid-bundleDependencies.ts
@@ -17,7 +17,7 @@ export const rule = createRule({
 				context.report({
 					data: {
 						errors: formatErrors(errors),
-						property: node.key.value,
+						property: (node.key as JsonAST.JSONStringLiteral).value,
 					},
 					messageId: "validationError",
 					node: bundleDependenciesValueNode,

--- a/src/rules/valid-bundleDependencies.ts
+++ b/src/rules/valid-bundleDependencies.ts
@@ -39,7 +39,7 @@ export const rule = createRule({
 			recommended: true,
 		},
 		messages: {
-			validationError: "Invalid bin: {{ errors }}",
+			validationError: "Invalid bundleDependencies: {{ errors }}",
 		},
 		schema: [],
 		type: "problem",

--- a/src/rules/valid-bundleDependencies.ts
+++ b/src/rules/valid-bundleDependencies.ts
@@ -17,6 +17,7 @@ export const rule = createRule({
 				context.report({
 					data: {
 						errors: formatErrors(errors),
+						property: node.key.value,
 					},
 					messageId: "validationError",
 					node: bundleDependenciesValueNode,
@@ -39,7 +40,7 @@ export const rule = createRule({
 			recommended: true,
 		},
 		messages: {
-			validationError: "Invalid bundleDependencies: {{ errors }}",
+			validationError: "Invalid {{ property }}: {{ errors }}",
 		},
 		schema: [],
 		type: "problem",

--- a/src/rules/valid-bundleDependencies.ts
+++ b/src/rules/valid-bundleDependencies.ts
@@ -1,0 +1,47 @@
+import { AST as JsonAST } from "jsonc-eslint-parser";
+import { validateBundleDependencies } from "package-json-validator";
+
+import { createRule } from "../createRule.js";
+import { formatErrors } from "../utils/formatErrors.js";
+
+export const rule = createRule({
+	create(context) {
+		const checkBundleDependencies = (node: JsonAST.JSONProperty) => {
+			const bundleDependenciesValueNode = node.value;
+			const bundleDependenciesValue: unknown = JSON.parse(
+				context.sourceCode.getText(bundleDependenciesValueNode),
+			);
+
+			const errors = validateBundleDependencies(bundleDependenciesValue);
+			if (errors.length) {
+				context.report({
+					data: {
+						errors: formatErrors(errors),
+					},
+					messageId: "validationError",
+					node: bundleDependenciesValueNode,
+				});
+			}
+		};
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=bundledDependencies]":
+				checkBundleDependencies,
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=bundleDependencies]":
+				checkBundleDependencies,
+		};
+	},
+
+	meta: {
+		docs: {
+			category: "Best Practices",
+			description:
+				"Enforce that the `bundleDependencies` (or `bundledDependencies`) property is valid.",
+			recommended: true,
+		},
+		messages: {
+			validationError: "Invalid bin: {{ errors }}",
+		},
+		schema: [],
+		type: "problem",
+	},
+});

--- a/src/tests/rules/valid-bundleDependencies.test.ts
+++ b/src/tests/rules/valid-bundleDependencies.test.ts
@@ -13,6 +13,7 @@ ruleTester.run("valid-bundleDependencies", rule, {
 					{
 						data: {
 							errors: "the field is `null`, but should be an `Array` or a `boolean`",
+							property,
 						},
 						messageId: "validationError",
 					},
@@ -27,6 +28,7 @@ ruleTester.run("valid-bundleDependencies", rule, {
 					{
 						data: {
 							errors: "the type should be `Array` or `boolean`, not `number`",
+							property,
 						},
 						messageId: "validationError",
 					},
@@ -41,6 +43,7 @@ ruleTester.run("valid-bundleDependencies", rule, {
 					{
 						data: {
 							errors: "the type should be `Array` or `boolean`, not `string`",
+							property,
 						},
 						messageId: "validationError",
 					},
@@ -55,6 +58,7 @@ ruleTester.run("valid-bundleDependencies", rule, {
 					{
 						data: {
 							errors: "the type should be `Array` or `boolean`, not `object`",
+							property,
 						},
 						messageId: "validationError",
 					},
@@ -72,6 +76,7 @@ ruleTester.run("valid-bundleDependencies", rule, {
  - item at index 1 is empty, but should be a dependency name
  - item at index 2 should be a string, not \`number\`
  - item at index 3 should be a string, not \`null\``,
+							property,
 						},
 						messageId: "validationError",
 					},

--- a/src/tests/rules/valid-bundleDependencies.test.ts
+++ b/src/tests/rules/valid-bundleDependencies.test.ts
@@ -1,0 +1,93 @@
+import { rule } from "../../rules/valid-bundleDependencies.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-bundleDependencies", rule, {
+	invalid: ["bundleDependencies", "bundledDependencies"]
+		.map((property) => [
+			{
+				code: `{
+	"${property}": null
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the field is `null`, but should be an `Array` or a `boolean`",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"${property}": 123
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the type should be `Array` or `boolean`, not `number`",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"${property}": "invalid"
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the type should be `Array` or `boolean`, not `string`",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"${property}": { "invalid-bin": 123 }
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the type should be `Array` or `boolean`, not `object`",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"${property}": ["valid", "", 123, null]
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: `
+ - item at index 1 is empty, but should be a dependency name
+ - item at index 2 should be a string, not \`number\`
+ - item at index 3 should be a string, not \`null\``,
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+		])
+		.flat(),
+	valid: [
+		"{}",
+		...["bundleDependencies", "bundledDependencies"]
+			.map((property) => [
+				`{ "${property}": true }`,
+				`{ "${property}": false }`,
+				`{ "${property}": [] }`,
+				`{ "${property}": ["nin", "silver-mt-zion"] }`,
+			])
+			.flat(),
+	],
+});


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #819
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `valid-bundleDependencies` rule that uses `validateBundleDependencies` from package-json-validator to identify errors.
