### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -124,6 +124,7 @@ export const rule = createRule<Options>({
 		},
 		schema: [
 			{
+				additionalProperties: false,
 				properties: {
 					order: {
 						anyOf: [

--- a/src/rules/repository-shorthand.ts
+++ b/src/rules/repository-shorthand.ts
@@ -144,6 +144,7 @@ export const rule = createRule<Options>({
 		},
 		schema: [
 			{
+				additionalProperties: false,
 				properties: {
 					form: {
 						enum: ["object", "shorthand"],

--- a/src/rules/valid-bin.ts
+++ b/src/rules/valid-bin.ts
@@ -78,6 +78,7 @@ export const rule = createRule<Options>({
 		},
 		schema: [
 			{
+				additionalProperties: false,
 				properties: {
 					enforceCase: {
 						default: false,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/1155
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR simply disallows extra properties in rules' schemas which currently allow them.
