### PR TITLE
feat: add `ignorePrivate` option to all `require-*` rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,10 @@ export default {
 
 #### `enforceForPrivate`
 
-Whether `require-*` rules, if used, should enforce the presence of the corresponding property in package.json files with `"private": true`.
-Possible values are:
+**Type:** `boolean`
 
-- `boolean`
-- Not set (default): all `require-*` rules except for [`require-name`](docs/rules/require-name.md) and [`require-version`](docs/rules/require-version.md) will report if the corresponding property is missing in package.json with `"private": true`.
+Determines whether `require-*` rules, if used, should enforce the presence of the corresponding property in package.json files with `"private": true`.
+By default, all `require-*` rules except for [`require-name`](docs/rules/require-name.md) and [`require-version`](docs/rules/require-version.md) will report if the corresponding property is missing in package.json with `"private": true`.
 
 ### Usage Alongside Prettier
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Whether `require-*` rules, if used, should enforce the presence of the correspon
 Possible values are:
 
 - `boolean`
-- `"recommended"` (default): all `require-*` rules except for [`require-name`](docs/rules/require-name.md) and [`require-version`](docs/rules/require-version.md) will report if the corresponding property is missing in package.json with `"private": true`.
+- Not set (default): all `require-*` rules except for [`require-name`](docs/rules/require-name.md) and [`require-version`](docs/rules/require-version.md) will report if the corresponding property is missing in package.json with `"private": true`.
 
 ### Usage Alongside Prettier
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,41 @@ module.exports = {
 };
 ```
 
+### Settings
+
+Some rules can be configured in ESLint shared settings.
+You can set them in `settings.packageJson` in an ESLint flat config.
+
+Example:
+
+```ts
+// eslint.config.ts
+import packageJson from "eslint-plugin-package-json";
+
+export default {
+	plugins: {
+		"package-json": packageJson,
+	},
+	rules: {
+		// `description` won't be required in package.json with `"private": true`
+		"package-json/require-description": "error",
+	},
+	settings: {
+		packageJson: {
+			enforceForPrivate: false,
+		},
+	},
+};
+```
+
+#### `enforceForPrivate`
+
+Whether `require-*` rules, if used, should enforce the presence of the corresponding property in package.json files with `"private": true`.
+Possible values are:
+
+- `boolean`
+- `"recommended"` (default): all `require-*` rules except for [`require-name`](docs/rules/require-name.md) and [`require-version`](docs/rules/require-version.md) will report if the corresponding property is missing in package.json with `"private": true`.
+
 ### Usage Alongside Prettier
 
 **[`prettier-plugin-packagejson`](https://github.com/matzkoh/prettier-plugin-packagejson)** is a [Prettier plugin](https://prettier.io/docs/en/plugins) that enforces the same `package.json` keys ordering as the [`order-properties`](docs/rules/order-properties.md) and [sort-collections](docs/rules/sort-collections.md) rules with default options.

--- a/docs/rules/require-author.md
+++ b/docs/rules/require-author.md
@@ -22,3 +22,55 @@ Example of **correct** code for this rule:
 	"author": "Jessica Moss"
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-author": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"author": "Jessica Moss"
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-author.md
+++ b/docs/rules/require-author.md
@@ -23,7 +23,7 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
 You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
 

--- a/docs/rules/require-bugs.md
+++ b/docs/rules/require-bugs.md
@@ -25,3 +25,54 @@ Example of **correct** code for this rule:
 	}
 }
 ```
+
+## Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-author": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"bugs": {
+		"url": "https://github.com/owner/project/issues",
+		"email": "project@hostname.com"
+	}
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-bundleDependencies.md
+++ b/docs/rules/require-bundleDependencies.md
@@ -22,3 +22,51 @@ Example of **correct** code for this rule:
 	"bundleDependencies": ["renderized", "super-streams"]
 }
 ```
+
+## Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-author": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"bundleDependencies": ["renderized", "super-streams"]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-dependencies.md
+++ b/docs/rules/require-dependencies.md
@@ -24,3 +24,53 @@ Example of **correct** code for this rule:
 	}
 }
 ```
+
+## Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-author": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"dependencies": {
+		"gybe": "^1.2.3"
+	}
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -25,7 +25,7 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
 You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
 

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -24,3 +24,55 @@ Example of **correct** code for this rule:
 	"description": "Thee Silver Mt. Zion."
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-description": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"description": "Thee Silver Mt. Zion."
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-devDependencies.md
+++ b/docs/rules/require-devDependencies.md
@@ -24,3 +24,53 @@ Example of **correct** code for this rule:
 	}
 }
 ```
+
+## Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-author": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"devDependencies": {
+		"gybe": "^1.2.3"
+	}
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-engines.md
+++ b/docs/rules/require-engines.md
@@ -25,7 +25,7 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
 You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
 

--- a/docs/rules/require-engines.md
+++ b/docs/rules/require-engines.md
@@ -24,3 +24,57 @@ Example of **correct** code for this rule:
 	}
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-engines": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"engines": {
+		"node": ">=18"
+	}
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-files.md
+++ b/docs/rules/require-files.md
@@ -22,3 +22,55 @@ Example of **correct** code for this rule:
 	"files": ["lib"]
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-files": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"files": ["lib"]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-files.md
+++ b/docs/rules/require-files.md
@@ -23,7 +23,7 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
 You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
 

--- a/docs/rules/require-keywords.md
+++ b/docs/rules/require-keywords.md
@@ -22,3 +22,55 @@ Example of **correct** code for this rule:
 	"keywords": ["eslint"]
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-keywords": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"keywords": ["eslint"]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-keywords.md
+++ b/docs/rules/require-keywords.md
@@ -23,7 +23,7 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
 You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
 

--- a/docs/rules/require-name.md
+++ b/docs/rules/require-name.md
@@ -25,9 +25,10 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
-You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true`. This is the default.
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true`.
+This is the default.
 
 ```json
 {

--- a/docs/rules/require-name.md
+++ b/docs/rules/require-name.md
@@ -24,3 +24,55 @@ Example of **correct** code for this rule:
 	"author": "Jessica Moss"
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true`. This is the default.
+
+```json
+{
+	"package-json/require-name": [
+		"error",
+		{
+			"ignorePrivate": true
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"name": "thee-silver-mt-zion"
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-optionalDependencies.md
+++ b/docs/rules/require-optionalDependencies.md
@@ -24,3 +24,53 @@ Example of **correct** code for this rule:
 	}
 }
 ```
+
+## Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-author": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"optionalDependencies": {
+		"gybe": "^1.2.3"
+	}
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-peerDependencies.md
+++ b/docs/rules/require-peerDependencies.md
@@ -24,3 +24,53 @@ Example of **correct** code for this rule:
 	}
 }
 ```
+
+## Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-author": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"peerDependencies": {
+		"gybe": "^1.2.3"
+	}
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-type.md
+++ b/docs/rules/require-type.md
@@ -25,7 +25,7 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
 You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
 

--- a/docs/rules/require-type.md
+++ b/docs/rules/require-type.md
@@ -24,3 +24,55 @@ Example of **correct** code for this rule:
 	"type": "module"
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-type": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"type": "module"
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-types.md
+++ b/docs/rules/require-types.md
@@ -25,7 +25,7 @@ Example of **correct** code for this rule:
 
 See [TypeScript Handbook > Publishing](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) for more information on publishing package types.
 
-### Options
+## Options
 
 You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
 

--- a/docs/rules/require-types.md
+++ b/docs/rules/require-types.md
@@ -24,3 +24,55 @@ Example of **correct** code for this rule:
 ```
 
 See [TypeScript Handbook > Publishing](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html) for more information on publishing package types.
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-types": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"types": "./index.d.ts"
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/docs/rules/require-version.md
+++ b/docs/rules/require-version.md
@@ -23,9 +23,10 @@ Example of **correct** code for this rule:
 }
 ```
 
-### Options
+## Options
 
-You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true`. This is the default.
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true`.
+This is the default.
 
 ```json
 {

--- a/docs/rules/require-version.md
+++ b/docs/rules/require-version.md
@@ -22,3 +22,55 @@ Example of **correct** code for this rule:
 	"version": "13.0.0"
 }
 ```
+
+### Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json files with `"private": true`. This is the default.
+
+```json
+{
+	"package-json/require-version": [
+		"error",
+		{
+			"ignorePrivate": true
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"version": "13.0.0"
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -26,10 +26,9 @@ export interface PackageJsonPluginSettings {
 	 * Whether `require-*` rules, if used, should enforce the presence of
 	 * the corresponding property *in package.json files with `"private": true`*.
 	 *
-	 * `'recommended'` will not enforce the presence only of `name` and `version` properties.
-	 * @default 'recommended'
+	 * If not specified, it will not enforce the presence only of `name` and `version` properties.
 	 */
-	enforceForPrivate?: "recommended" | boolean;
+	enforceForPrivate?: boolean;
 }
 
 export interface PackageJsonRuleContext<Options extends unknown[] = unknown[]>

--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -21,9 +21,23 @@ export interface PackageJsonAst extends AST.Program {
 	body: [JsonAstBodyStatement];
 }
 
+export interface PackageJsonPluginSettings {
+	/**
+	 * Whether `require-*` rules, if used, should enforce the presence of
+	 * the corresponding property *in package.json files with `"private": true`*.
+	 *
+	 * `'recommended'` will not enforce the presence only of `name` and `version` properties.
+	 * @default 'recommended'
+	 */
+	enforceForPrivate?: "recommended" | boolean;
+}
+
 export interface PackageJsonRuleContext<Options extends unknown[] = unknown[]>
 	extends Rule.RuleContext {
 	options: Options;
+	settings: {
+		packageJson?: PackageJsonPluginSettings;
+	};
 	sourceCode: PackageJsonSourceCode;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,3 +4,5 @@ export const rules = plugin.rules;
 export const configs = plugin.configs;
 
 export default plugin;
+
+export type { PackageJsonPluginSettings } from "./createRule.js";

--- a/src/rules/require-properties.ts
+++ b/src/rules/require-properties.ts
@@ -18,7 +18,7 @@ const properties: {
 	{ name: "keywords" },
 	{
 		name: "name",
-		options: { isOptionalForPrivatePackages: true, isRecommended: true },
+		options: { ignorePrivateDefault: true, isRecommended: true },
 	},
 	{ name: "optionalDependencies" },
 	{ name: "peerDependencies" },
@@ -26,7 +26,7 @@ const properties: {
 	{ name: "types" },
 	{
 		name: "version",
-		options: { isOptionalForPrivatePackages: true, isRecommended: true },
+		options: { ignorePrivateDefault: true, isRecommended: true },
 	},
 ];
 

--- a/src/rules/require-properties.ts
+++ b/src/rules/require-properties.ts
@@ -3,35 +3,27 @@ import {
 	createSimpleRequirePropertyRule,
 } from "../utils/createSimpleRequirePropertyRule.js";
 
-const properties: {
-	name: string;
-	options?: CreateRequirePropertyRuleOptions;
-}[] = [
-	{ name: "author" },
-	{ name: "bugs" },
-	{ name: "bundleDependencies" },
-	{ name: "dependencies" },
-	{ name: "description", options: { isRecommended: true } },
-	{ name: "devDependencies" },
-	{ name: "engines" },
-	{ name: "files" },
-	{ name: "keywords" },
-	{
-		name: "name",
-		options: { ignorePrivateDefault: true, isRecommended: true },
-	},
-	{ name: "optionalDependencies" },
-	{ name: "peerDependencies" },
-	{ name: "type", options: { isRecommended: true } },
-	{ name: "types" },
-	{
-		name: "version",
-		options: { ignorePrivateDefault: true, isRecommended: true },
-	},
-];
+const properties: [name: string, options?: CreateRequirePropertyRuleOptions][] =
+	[
+		["author"],
+		["bugs"],
+		["bundleDependencies"],
+		["dependencies"],
+		["description", { isRecommended: true }],
+		["devDependencies"],
+		["engines"],
+		["files"],
+		["keywords"],
+		["name", { ignorePrivateDefault: true, isRecommended: true }],
+		["optionalDependencies"],
+		["peerDependencies"],
+		["type", { isRecommended: true }],
+		["types"],
+		["version", { ignorePrivateDefault: true, isRecommended: true }],
+	];
 
 export const rules = Object.fromEntries(
-	properties.map(({ name: propertyName, options }) => [
+	properties.map(([propertyName, options]) => [
 		`require-${propertyName}`,
 		createSimpleRequirePropertyRule(propertyName, options),
 	]),

--- a/src/rules/require-properties.ts
+++ b/src/rules/require-properties.ts
@@ -1,36 +1,38 @@
-import type { PackageJsonRuleModule } from "../createRule.js";
+import {
+	type CreateRequirePropertyRuleOptions,
+	createSimpleRequirePropertyRule,
+} from "../utils/createSimpleRequirePropertyRule.js";
 
-import { createSimpleRequirePropertyRule } from "../utils/createSimpleRequirePropertyRule.js";
-
-// List of all properties we want to create require- rules for,
-// in the format [propertyName, isRecommended]
-const properties = [
-	["author", false],
-	["bugs", false],
-	["bundleDependencies", false],
-	["dependencies", false],
-	["devDependencies", false],
-	["description", true],
-	["engines", false],
-	["files", false],
-	["keywords", false],
-	["name", true],
-	["optionalDependencies", false],
-	["peerDependencies", false],
-	["type", true],
-	["types", false],
-	["version", true],
-	// TODO: More to come!
-] satisfies [string, boolean][];
-
-/** All require- flavor rules */
-export const rules = properties.reduce<Record<string, PackageJsonRuleModule>>(
-	(acc, [propertyName, isRecommended]) => {
-		acc[`require-${propertyName}`] = createSimpleRequirePropertyRule(
-			propertyName,
-			isRecommended,
-		);
-		return acc;
+const properties: {
+	name: string;
+	options?: CreateRequirePropertyRuleOptions;
+}[] = [
+	{ name: "author" },
+	{ name: "bugs" },
+	{ name: "bundleDependencies" },
+	{ name: "dependencies" },
+	{ name: "description", options: { isRecommended: true } },
+	{ name: "devDependencies" },
+	{ name: "engines" },
+	{ name: "files" },
+	{ name: "keywords" },
+	{
+		name: "name",
+		options: { isOptionalForPrivatePackages: true, isRecommended: true },
 	},
-	{},
+	{ name: "optionalDependencies" },
+	{ name: "peerDependencies" },
+	{ name: "type", options: { isRecommended: true } },
+	{ name: "types" },
+	{
+		name: "version",
+		options: { isOptionalForPrivatePackages: true, isRecommended: true },
+	},
+];
+
+export const rules = Object.fromEntries(
+	properties.map(({ name: propertyName, options }) => [
+		`require-${propertyName}`,
+		createSimpleRequirePropertyRule(propertyName, options),
+	]),
 );

--- a/src/tests/rules/require-properties.test.ts
+++ b/src/tests/rules/require-properties.test.ts
@@ -1,3 +1,5 @@
+import type { PackageJsonPluginSettings } from "../../createRule.js";
+
 import { rules } from "../../rules/require-properties.js";
 import { ruleTester } from "./ruleTester.js";
 
@@ -49,12 +51,321 @@ ruleNames.forEach((ruleName) => {
 					},
 				],
 			},
+			{
+				code: `{
+          "private": true
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: false }],
+			},
+			{
+				code: `{
+          "private": false
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: true }],
+			},
+			{
+				code: `{
+          "private": "true"
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: true }],
+			},
+			{
+				code: `{}`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: true }],
+			},
+			{
+				code: `{
+          "private": false
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+			},
+			{
+				code: `{
+          "private": true
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				settings: {
+					packageJson: {
+						enforceForPrivate: true,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": true
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: false }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: true,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": false
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: true }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: true,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{}`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: true }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: true,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": true
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: false }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: false,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": false
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				settings: {
+					packageJson: {
+						enforceForPrivate: false,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": false
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: false }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: false,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": false
+          }`,
+				errors: [
+					{
+						data: { property: propertyName },
+						line: 1,
+						messageId: "missing",
+					},
+				],
+				options: [{ ignorePrivate: true }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: false,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
 		],
 		valid: [
 			`{ "foo": "./index.js", "${propertyName}": "Sophie Trudeau" }`,
 			`{ "${propertyName}": "Jessica Moss" }`,
 			`{ "${propertyName}": 123 }`,
 			`{ "${propertyName}": { "name": "Jessica Moss" } }`,
+			{
+				code: `{
+          "private": true,
+          "${propertyName}": "Jessica Moss"
+          }`,
+			},
+			{
+				code: `{
+          "private": true
+          }`,
+				options: [{ ignorePrivate: true }],
+			},
+			{
+				code: `{
+          "private": true,
+          "${propertyName}": "Jessica Moss"
+          }`,
+				options: [{ ignorePrivate: false }],
+			},
+			{
+				code: `{
+          "private": false,
+          "${propertyName}": "Jessica Moss"
+          }`,
+				options: [{ ignorePrivate: true }],
+			},
+			{
+				code: `{
+          "private": false,
+          "${propertyName}": "Jessica Moss"
+          }`,
+				options: [{ ignorePrivate: false }],
+			},
+			{
+				code: `{
+          "private": "true",
+          "${propertyName}": "Jessica Moss"
+          }`,
+				options: [{ ignorePrivate: true }],
+			},
+			{
+				code: `{
+          "private": true,
+          "${propertyName}": "Jessica Moss"
+          }`,
+				settings: {
+					packageJson: {
+						enforceForPrivate: true,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": true
+          }`,
+				options: [{ ignorePrivate: true }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: true,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": true,
+          "${propertyName}": "Jessica Moss"
+          }`,
+				options: [{ ignorePrivate: false }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: true,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": true
+          }`,
+				settings: {
+					packageJson: {
+						enforceForPrivate: false,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": true
+          }`,
+				options: [{ ignorePrivate: true }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: false,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
+			{
+				code: `{
+          "private": true,
+          "${propertyName}": "Jessica Moss"
+          }`,
+				options: [{ ignorePrivate: false }],
+				settings: {
+					packageJson: {
+						enforceForPrivate: false,
+					} satisfies PackageJsonPluginSettings,
+				},
+			},
 		],
 	});
 });

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -77,8 +77,7 @@ export const createSimpleRequirePropertyRule = (
 		},
 		meta: {
 			docs: {
-				description:
-					"Requires the `${propertyName}` property to be present.",
+				description: `Requires the \`${propertyName}\` property to be present.`,
 				recommended: isRecommended,
 			},
 			messages: {

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -3,6 +3,13 @@ import type { AST as JsonAST } from "jsonc-eslint-parser";
 import { createRule } from "../createRule.js";
 import { isJSONStringLiteral } from "./predicates.js";
 
+export interface CreateRequirePropertyRuleOptions {
+	isOptionalForPrivatePackages?: boolean;
+	isRecommended?: boolean;
+}
+
+type Options = [{ ignorePrivate?: boolean }?];
+
 /**
  * Given a top-level property name, create a rule that requires that property to be present.
  * Optionally, include it in the recommended config.
@@ -11,14 +18,35 @@ import { isJSONStringLiteral } from "./predicates.js";
  */
 export const createSimpleRequirePropertyRule = (
 	propertyName: string,
-	isRecommended = false,
+	{
+		isOptionalForPrivatePackages,
+		isRecommended,
+	}: CreateRequirePropertyRuleOptions = {},
 ) => {
-	return createRule({
+	const ignorePrivateDefault = isOptionalForPrivatePackages ?? false;
+
+	return createRule<Options>({
 		create(context) {
 			return {
 				"Program > JSONExpressionStatement > JSONObjectExpression"(
 					node: JsonAST.JSONObjectExpression,
 				) {
+					const ignorePrivate =
+						context.options[0]?.ignorePrivate ??
+						ignorePrivateDefault;
+					if (
+						ignorePrivate &&
+						node.properties.some(
+							(property) =>
+								isJSONStringLiteral(property.key) &&
+								property.key.value === "private" &&
+								property.value.type === "JSONLiteral" &&
+								property.value.value === true,
+						)
+					) {
+						return;
+					}
+
 					if (
 						!node.properties.some(
 							(property) =>
@@ -43,7 +71,18 @@ export const createSimpleRequirePropertyRule = (
 			messages: {
 				missing: "Property '{{property}}' is required.",
 			},
-			schema: [],
+			schema: [
+				{
+					additionalProperties: false,
+					properties: {
+						ignorePrivate: {
+							default: ignorePrivateDefault,
+							type: "boolean",
+						},
+					},
+					type: "object",
+				},
+			],
 			type: "suggestion",
 		},
 	});

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -33,8 +33,7 @@ export const createSimpleRequirePropertyRule = (
 	return createRule<Options>({
 		create(context) {
 			const enforceForPrivate =
-				context.settings.packageJson?.enforceForPrivate ??
-				"recommended";
+				context.settings.packageJson?.enforceForPrivate;
 
 			const ignorePrivate =
 				context.options[0]?.ignorePrivate ??


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1092
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR adds `ignorePrivate` option to all `require-*` rules to skip package.json files with `private: true`. It's set to `true` by default only for `require-{name,version}` rules.

@JoshuaKGoldberg [suggested introducing](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues/1092#issuecomment-2976567386) a global option to control the behavior of the rules in case of private packages, but I'm not too sure how it would work.
