### PR TITLE
feat(valid-license): add new rule for validating `license`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-author](docs/rules/valid-author.md)                             | Enforce that the author field is a valid npm author specification                                 | ✔️ ✅ |    |    |    |
 | [valid-bin](docs/rules/valid-bin.md)                                   | Enforce that the `bin` property is valid.                                                         | ✔️ ✅ |    | 💡 |    |
 | [valid-bundleDependencies](docs/rules/valid-bundleDependencies.md)     | Enforce that the `bundleDependencies` (or `bundledDependencies`) property is valid.               | ✔️ ✅ |    |    |    |
+| [valid-license](docs/rules/valid-license.md)                           | Enforce that the `license` property is valid.                                                     | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        |      |    |    | ❌  |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |
 | [valid-package-definition](docs/rules/valid-package-definition.md)     | Enforce that package.json has all properties required by the npm spec                             | ✔️ ✅ |    |    |    |

--- a/docs/rules/valid-license.md
+++ b/docs/rules/valid-license.md
@@ -1,0 +1,28 @@
+# valid-license
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+This rule does the following checks on the value of the `license` property:
+
+- It must be a `string`
+- The value should be a valid SPDX license, "UNLICENSED", or a note referencing a license file (e.g. "SEE LICENSE IN LICENSE.md")
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"license": "GPL3"
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"license": "GPL-3.0-only"
+}
+```
+
+**See also:** [SPDX Documentation](https://spdx.org/licenses/)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"detect-indent": "^7.0.1",
 		"detect-newline": "^4.0.1",
 		"eslint-fix-utils": "~0.4.0",
-		"package-json-validator": "~0.20.0",
+		"package-json-validator": "~0.22.0",
 		"semver": "^7.5.4",
 		"sort-object-keys": "^1.1.3",
 		"sort-package-json": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ~0.4.0
         version: 0.4.0(@types/estree@1.0.7)(eslint@9.30.0(jiti@2.4.2))
       package-json-validator:
-        specifier: ~0.20.0
-        version: 0.20.1
+        specifier: ~0.22.0
+        version: 0.22.0
       semver:
         specifier: ^7.5.4
         version: 7.7.2
@@ -3183,8 +3183,8 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-json-validator@0.20.1:
-    resolution: {integrity: sha512-ZFGIYroTnzozNtDpJDaN9w7bq0ssMSWA2Ea751JeUXdu2MBf0pd+Dhk+s9Q34ST9M7RZuwp4eqIASt59qZ2vIQ==}
+  package-json-validator@0.22.0:
+    resolution: {integrity: sha512-XzCbXfWUhQX60ONIYuJQQ1GWXJLVSD17XNFjU+fk0ckihpsoOc0TZ685x5yb3cAi8W0vt52icQCsnQXZUOZrkQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7411,8 +7411,9 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  package-json-validator@0.20.1:
+  package-json-validator@0.22.0:
     dependencies:
+      validate-npm-package-license: 3.0.4
       yargs: 18.0.0
 
   parent-module@1.0.1:

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,6 +15,7 @@ import { rule as uniqueDependencies } from "./rules/unique-dependencies.js";
 import { rule as validAuthor } from "./rules/valid-author.js";
 import { rule as validBin } from "./rules/valid-bin.js";
 import { rule as validBundleDependencies } from "./rules/valid-bundleDependencies.js";
+import { rule as validLicense } from "./rules/valid-license.js";
 import { rule as validLocalDependency } from "./rules/valid-local-dependency.js";
 import { rule as validName } from "./rules/valid-name.js";
 import { rule as validPackageDefinition } from "./rules/valid-package-definition.js";
@@ -42,6 +43,7 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	"valid-author": validAuthor,
 	"valid-bin": validBin,
 	"valid-bundleDependencies": validBundleDependencies,
+	"valid-license": validLicense,
 	"valid-local-dependency": validLocalDependency,
 	"valid-name": validName,
 	"valid-package-definition": validPackageDefinition,

--- a/src/rules/valid-license.ts
+++ b/src/rules/valid-license.ts
@@ -1,0 +1,44 @@
+import { AST as JsonAST } from "jsonc-eslint-parser";
+import { validateLicense } from "package-json-validator";
+
+import { createRule } from "../createRule.js";
+import { formatErrors } from "../utils/formatErrors.js";
+
+export const rule = createRule({
+	create(context) {
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=license]"(
+				node: JsonAST.JSONProperty,
+			) {
+				const valueNode = node.value;
+				const value: unknown = JSON.parse(
+					context.sourceCode.getText(valueNode),
+				);
+
+				const errors = validateLicense(value);
+				if (errors.length) {
+					context.report({
+						data: {
+							errors: formatErrors(errors),
+						},
+						messageId: "validationError",
+						node: valueNode,
+					});
+				}
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: "Best Practices",
+			description: "Enforce that the `license` property is valid.",
+			recommended: true,
+		},
+		messages: {
+			validationError: "Invalid license: {{ errors }}",
+		},
+		schema: [],
+		type: "problem",
+	},
+});

--- a/src/tests/rules/valid-license.test.ts
+++ b/src/tests/rules/valid-license.test.ts
@@ -1,0 +1,69 @@
+import { rule } from "../../rules/valid-license.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-license", rule, {
+	invalid: [
+		{
+			code: `{
+	"license": null
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the field is `null`, but should be a `string`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"license": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be a `string`, not `number`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"license": ""
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the value is empty, but should be a valid license",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"license": "not-a-license"
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: 'license should be a valid SPDX license expression (without "LicenseRef"), "UNLICENSED", or "SEE LICENSE IN <filename>"',
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		`{ "license": "MIT" }`,
+		`{ "license": "UNLICENSED" }`,
+		`{ "license": "SEE LICENSE IN LICENSE.md" }`,
+	],
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #830
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `valid-license` rule that uses `validateLicense` from package-json-validator to identify errors.
