### PR TITLE
fix(valid-repository-directory): use correct path separator when on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - run: pnpm format --list-different
   test:
     name: Test (Node.js ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +68,9 @@ jobs:
           - 20
           - 22
           - 24
+        os:
+          - ubuntu-latest
+          - windows-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - uses: ./.github/actions/prepare

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: ./.github/actions/prepare
       - run: pnpm format --list-different
   test:
-    name: Test (Node.js ${{ matrix.node-version }})
+    name: Test (Node.js ${{ matrix.node-version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/src/rules/valid-repository-directory.ts
+++ b/src/rules/valid-repository-directory.ts
@@ -2,6 +2,7 @@ import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import { findRootSync } from "@altano/repository-tools";
 import * as path from "node:path";
+import { sep as posixSep } from "node:path/posix";
 
 import { createRule } from "../createRule.js";
 import { findPropertyWithKeyValue } from "../utils/findPropertyWithKeyValue.js";
@@ -99,11 +100,9 @@ export const rule = createRule({
 					//     fileDirectory: '~/src/project/packages/packageA',
 					//     expected: 'packages/packageA'
 					//
-					const expected = path.relative(
-						repositoryRoot,
-						fileDirectory,
-					);
-
+					const expected = path
+						.relative(repositoryRoot, fileDirectory)
+						.replaceAll(path.sep, posixSep);
 					if (expected !== directoryValue) {
 						context.report({
 							messageId: "mismatched",

--- a/src/tests/rules/valid-repository-directory.test.ts
+++ b/src/tests/rules/valid-repository-directory.test.ts
@@ -131,7 +131,7 @@ ruleTester.run("valid-repository-directory (this repository)", rule, {
 					],
 				},
 			],
-			filename: `${thisRepoDirectory}/package.json`,
+			filename: path.resolve(thisRepoDirectory, "./package.json"),
 			name: `root package.json`,
 		},
 		{
@@ -160,7 +160,10 @@ ruleTester.run("valid-repository-directory (this repository)", rule, {
 					],
 				},
 			],
-			filename: `${thisRepoDirectory}/src/tests/__fixtures__/valid-local-dependency/package.json`,
+			filename: path.resolve(
+				thisRepoDirectory,
+				"./src/tests/__fixtures__/valid-local-dependency/package.json",
+			),
 			name: `nested package.json`,
 		},
 	],
@@ -173,7 +176,10 @@ ruleTester.run("valid-repository-directory (this repository)", rule, {
 		},
 		{
 			code: `{ "repository": { "directory": "src/tests/__fixtures__/valid-local-dependency" } }`,
-			filename: `${thisRepoDirectory}/src/tests/__fixtures__/valid-local-dependency/package.json`,
+			filename: path.resolve(
+				thisRepoDirectory,
+				"./src/tests/__fixtures__/valid-local-dependency/package.json",
+			),
 			name: `nested package.json`,
 		},
 	],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1175
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change addresses an issue with `valid-repository-directory` where the rule assumed users would always be in a posix environment.  The logic didn't account for windows path separators being different.  Now, at the end, we're swapping whatever separator the system is using with posix path separator.

I also updated our test ci steps to also run all tests on windows, in addition to what we already had (ubuntu).
