### PR TITLE
feat(valid-config): add new rule for validating `config`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-author](docs/rules/valid-author.md)                             | Enforce that the author field is a valid npm author specification                                 | ✔️ ✅ |    |    |    |
 | [valid-bin](docs/rules/valid-bin.md)                                   | Enforce that the `bin` property is valid.                                                         | ✔️ ✅ |    | 💡 |    |
 | [valid-bundleDependencies](docs/rules/valid-bundleDependencies.md)     | Enforce that the `bundleDependencies` (or `bundledDependencies`) property is valid.               | ✔️ ✅ |    |    |    |
+| [valid-config](docs/rules/valid-config.md)                             | Enforce that the `config` property is valid.                                                      | ✔️ ✅ |    |    |    |
 | [valid-license](docs/rules/valid-license.md)                           | Enforce that the `license` property is valid.                                                     | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        |      |    |    | ❌  |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |

--- a/docs/rules/valid-config.md
+++ b/docs/rules/valid-config.md
@@ -1,0 +1,28 @@
+# valid-config
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+The rule checks that, if present, the `config` property is an object.
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"config": true
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"config": {
+		"name": "foo",
+		"config": {
+			"port": "8080"
+		}
+	}
+}
+```

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -15,6 +15,7 @@ import { rule as uniqueDependencies } from "./rules/unique-dependencies.js";
 import { rule as validAuthor } from "./rules/valid-author.js";
 import { rule as validBin } from "./rules/valid-bin.js";
 import { rule as validBundleDependencies } from "./rules/valid-bundleDependencies.js";
+import { rule as validConfig } from "./rules/valid-config.js";
 import { rule as validLicense } from "./rules/valid-license.js";
 import { rule as validLocalDependency } from "./rules/valid-local-dependency.js";
 import { rule as validName } from "./rules/valid-name.js";
@@ -43,6 +44,7 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	"valid-author": validAuthor,
 	"valid-bin": validBin,
 	"valid-bundleDependencies": validBundleDependencies,
+	"valid-config": validConfig,
 	"valid-license": validLicense,
 	"valid-local-dependency": validLocalDependency,
 	"valid-name": validName,

--- a/src/rules/valid-config.ts
+++ b/src/rules/valid-config.ts
@@ -1,0 +1,44 @@
+import { AST as JsonAST } from "jsonc-eslint-parser";
+import { validateConfig } from "package-json-validator";
+
+import { createRule } from "../createRule.js";
+import { formatErrors } from "../utils/formatErrors.js";
+
+export const rule = createRule({
+	create(context) {
+		return {
+			"Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=config]"(
+				node: JsonAST.JSONProperty,
+			) {
+				const valueNode = node.value;
+				const value: unknown = JSON.parse(
+					context.sourceCode.getText(valueNode),
+				);
+
+				const errors = validateConfig(value);
+				if (errors.length) {
+					context.report({
+						data: {
+							errors: formatErrors(errors),
+						},
+						messageId: "validationError",
+						node: valueNode,
+					});
+				}
+			},
+		};
+	},
+
+	meta: {
+		docs: {
+			category: "Best Practices",
+			description: "Enforce that the `config` property is valid.",
+			recommended: true,
+		},
+		messages: {
+			validationError: "Invalid config: {{ errors }}",
+		},
+		schema: [],
+		type: "problem",
+	},
+});

--- a/src/tests/rules/valid-config.test.ts
+++ b/src/tests/rules/valid-config.test.ts
@@ -1,0 +1,69 @@
+import { rule } from "../../rules/valid-config.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-config", rule, {
+	invalid: [
+		{
+			code: `{
+	"config": null
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the field is `null`, but should be an `object`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"config": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `number`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"config": "./script.js"
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `string`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"config": []
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `array`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		`{ "config": { "silver-mt-zion": "node ./silver-mt-zion.js" } }`,
+		`{ "config": { "silver-mt-zion": "node ./silver-mt-zion.js", "nin": "node ./nin.js" } }`,
+		`{ "config": { "silver-mt-zion": {"leadSinger": "Efrim Manuel Menuck"}, "nin": "node ./nin.js" } }`,
+	],
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #820
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `valid-config` rule that uses `validateConfig` from package-json-validator to identify errors.  It's included in the `recommended` config.
