### PR TITLE
feat(no-empty-fields): Add `ignoreProperties` option

### DIFF
--- a/docs/rules/no-empty-fields.md
+++ b/docs/rules/no-empty-fields.md
@@ -33,3 +33,22 @@ Example of **correct** code for this rule:
 	}
 }
 ```
+
+## Options
+
+### `ignoreProperties`
+
+Pass an array of top-level package properties to ignore.
+When provided, any errors related to the properties won't cause the rule to report a violation.
+This can be useful if you're using tools that take configuration from package.json and accept an empty array or object as valid non-default configuration.
+
+Example of excluding the browserslist property used by [browserslist](https://www.npmjs.com/package/browserslist):
+
+```json
+{
+	"package-json/no-empty-fields": [
+		"error",
+		{ "ignoreProperties": ["browserslist"] }
+	]
+}
+```

--- a/docs/rules/no-empty-fields.md
+++ b/docs/rules/no-empty-fields.md
@@ -39,7 +39,7 @@ Example of **correct** code for this rule:
 ### `ignoreProperties`
 
 Pass an array of top-level package properties to ignore.
-When provided, any errors related to the properties won't cause the rule to report a violation.
+When provided, the rule won't report violations for the specified properties.
 This can be useful if you're using tools that take configuration from package.json and accept an empty array or object as valid non-default configuration.
 
 Example of excluding the browserslist property used by [browserslist](https://www.npmjs.com/package/browserslist):

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -94,9 +94,7 @@ const getTopLevelPropertyName = (
 	) {
 		n = n.parent;
 	}
-	return n.type === "JSONProperty"
-		? (n.key as JsonAST.JSONStringLiteral).value
-		: undefined;
+	return ((n as JsonAST.JSONProperty).key as JsonAST.JSONStringLiteral).value;
 };
 
 export const rule = createRule<Options>({
@@ -107,10 +105,7 @@ export const rule = createRule<Options>({
 			JSONArrayExpression(node: JsonAST.JSONArrayExpression) {
 				if (!node.elements.length) {
 					const topLevelProperty = getTopLevelPropertyName(node);
-					if (
-						topLevelProperty === undefined ||
-						!ignoreProperties.includes(topLevelProperty)
-					) {
+					if (!ignoreProperties.includes(topLevelProperty)) {
 						report(context, getNode(node));
 					}
 				}
@@ -118,10 +113,7 @@ export const rule = createRule<Options>({
 			JSONObjectExpression(node: JsonAST.JSONObjectExpression) {
 				if (!node.properties.length) {
 					const topLevelProperty = getTopLevelPropertyName(node);
-					if (
-						topLevelProperty === undefined ||
-						!ignoreProperties.includes(topLevelProperty)
-					) {
+					if (!ignoreProperties.includes(topLevelProperty)) {
 						report(context, getNode(node));
 					}
 				}

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -8,6 +8,11 @@ import * as ESTree from "estree";
 
 import { createRule, PackageJsonRuleContext } from "../createRule.js";
 
+interface Option {
+	ignoreProperties?: string[];
+}
+type Options = [Option?];
+
 const getDataAndMessageId = (
 	node:
 		| JsonAST.JSONArrayExpression
@@ -79,17 +84,46 @@ const getNode = (
 	return node.parent.type === "JSONProperty" ? node.parent : node;
 };
 
-export const rule = createRule({
+const getTopLevelPropertyName = (
+	node: JsonAST.JSONArrayExpression | JsonAST.JSONObjectExpression,
+) => {
+	let n: JsonAST.JSONNode = node;
+	while (
+		n.parent.parent?.parent?.type !== undefined &&
+		n.parent.parent.parent.type !== "Program"
+	) {
+		n = n.parent;
+	}
+	return n.type === "JSONProperty"
+		? (n.key as JsonAST.JSONStringLiteral).value
+		: undefined;
+};
+
+export const rule = createRule<Options>({
 	create(context) {
+		const ignoreProperties = context.options[0]?.ignoreProperties ?? [];
+
 		return {
 			JSONArrayExpression(node: JsonAST.JSONArrayExpression) {
 				if (!node.elements.length) {
-					report(context, getNode(node));
+					const topLevelProperty = getTopLevelPropertyName(node);
+					if (
+						topLevelProperty === undefined ||
+						!ignoreProperties.includes(topLevelProperty)
+					) {
+						report(context, getNode(node));
+					}
 				}
 			},
 			JSONObjectExpression(node: JsonAST.JSONObjectExpression) {
 				if (!node.properties.length) {
-					report(context, getNode(node));
+					const topLevelProperty = getTopLevelPropertyName(node);
+					if (
+						topLevelProperty === undefined ||
+						!ignoreProperties.includes(topLevelProperty)
+					) {
+						report(context, getNode(node));
+					}
 				}
 			},
 		};
@@ -108,7 +142,20 @@ export const rule = createRule({
 				"The field '{{field}}' does nothing and can be removed.",
 			remove: "Remove this empty field.",
 		},
-		schema: [],
+		schema: [
+			{
+				additionalProperties: false,
+				properties: {
+					ignoreProperties: {
+						items: {
+							type: "string",
+						},
+						type: "array",
+					},
+				},
+				type: "object",
+			},
+		],
 		type: "suggestion",
 	},
 });

--- a/src/tests/rules/no-empty-fields.test.ts
+++ b/src/tests/rules/no-empty-fields.test.ts
@@ -293,6 +293,85 @@ ruleTester.run("no-empty-fields", rule, {
 				},
 			],
 		},
+		{
+			code: `{
+\t\t"name": "test",
+\t\t"files": [],
+\t\t"browserslist": [],
+\t\t"scripts": {}
+}
+`,
+			errors: [
+				{
+					messageId: "emptyFields",
+					suggestions: [
+						{
+							messageId: "remove",
+							output: `{
+\t\t"name": "test",
+\t\t
+\t\t"browserslist": [],
+\t\t"scripts": {}
+}
+`,
+						},
+					],
+				},
+				{
+					messageId: "emptyFields",
+					suggestions: [
+						{
+							messageId: "remove",
+							output: `{
+\t\t"name": "test",
+\t\t"files": [],
+\t\t"browserslist": []
+\t\t
+}
+`,
+						},
+					],
+				},
+			],
+			options: [
+				{
+					ignoreProperties: ["browserslist"],
+				},
+			],
+		},
+		{
+			code: `{
+\t\t"name": "test",
+\t\t"browserslist": {
+\t\t\t"development": [],
+\t\t\t"production": [ "last 1 version", "> 1%", "not dead" ]
+\t\t}
+}
+`,
+			errors: [
+				{
+					messageId: "emptyFields",
+					suggestions: [
+						{
+							messageId: "remove",
+							output: `{
+\t\t"name": "test",
+\t\t"browserslist": {
+\t\t\t
+\t\t\t"production": [ "last 1 version", "> 1%", "not dead" ]
+\t\t}
+}
+`,
+						},
+					],
+				},
+			],
+			options: [
+				{
+					ignoreProperties: ["development"],
+				},
+			],
+		},
 	],
 	valid: [
 		`{ "name": "test", "files": ["index.js"] }`,
@@ -303,5 +382,21 @@ ruleTester.run("no-empty-fields", rule, {
 		`{ "name": "test", "peerDependencyMeta": { "@altano/repository-tools": { "optional": true } } }`,
 		`{ "name": "test", "peerDependencyMeta": { "@altano/repository-tools": { "optional": true, "test": [{"test": ["1"]}] } } }`,
 		`{ "name": "test", "peerDependencyMeta": { "@altano/repository-tools": { "optional": true, "test": ["field1"] } } }`,
+		{
+			code: `{ "name": "test", "browserslist": [] }`,
+			options: [
+				{
+					ignoreProperties: ["browserslist"],
+				},
+			],
+		},
+		{
+			code: `{ "name": "test", "browserslist": { "development": [], "production": [ "last 1 version", "> 1%", "not dead" ] } }`,
+			options: [
+				{
+					ignoreProperties: ["browserslist"],
+				},
+			],
+		},
 	],
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1182
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
* An "ignoreProperties" option is added to the `no-empty-fields` rule to specify top-level properties to ignore.
  * I considered ignoring the immediate property name instead, but that seemed too likely to lack context.
  * I considered allowing for "paths", like "browserslist.developement", to ignore only certain subproperties. But then we'd probably need to allow for wildcards and arrays of objects, and that seemed overly complex when the immediate need is satisfied by naming only the top-level property.
* Tests are added to verify correct behavior of the new option.
* Documentation is updated to document the new option.

🗂