### PR TITLE
fix(no-empty-fields): don't throw error on empty object

### DIFF
--- a/src/tests/rules/no-empty-fields.test.ts
+++ b/src/tests/rules/no-empty-fields.test.ts
@@ -189,7 +189,7 @@ ruleTester.run("no-empty-fields", rule, {
 \t\t\t\t"@altano/repository-tools": {
 \t\t\t\t\t\t"optional": true
 \t\t\t\t},
-\t\t\t\t"nin": {} 
+\t\t\t\t"nin": {}
 \t\t}
 }
 `,
@@ -205,7 +205,7 @@ ruleTester.run("no-empty-fields", rule, {
 \t\t\t\t"@altano/repository-tools": {
 \t\t\t\t\t\t"optional": true
 \t\t\t\t}
-\t\t\t\t 
+\t\t\t\t
 \t\t}
 }
 `,
@@ -374,6 +374,8 @@ ruleTester.run("no-empty-fields", rule, {
 		},
 	],
 	valid: [
+		`{}`,
+		`[]`,
 		`{ "name": "test", "files": ["index.js"] }`,
 		`{ "name": "test", "peerDependencies": { "eslint": ">=8.0.0" } }`,
 		`{ "name": "test", "dependencies": { "eslint": ">=8.0.0" } }`,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1188 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change fixes an issue with `no-empty-fields` where it errors out if the `package.json` consists of just an empty object (or array).
