### PR TITLE
feat(valid-dependencies): add new rule for validating dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-config](docs/rules/valid-config.md)                             | Enforce that the `config` property is valid.                                                      | ✔️ ✅ |    |    |    |
 | [valid-cpu](docs/rules/valid-cpu.md)                                   | Enforce that the `cpu` property is valid.                                                         | ✔️ ✅ |    |    |    |
 | [valid-dependencies](docs/rules/valid-dependencies.md)                 | Enforce that the `dependencies` property is valid.                                                | ✔️ ✅ |    |    |    |
+| [valid-devDependencies](docs/rules/valid-devDependencies.md)           | Enforce that the `devDependencies` property is valid.                                             | ✔️ ✅ |    |    |    |
 | [valid-license](docs/rules/valid-license.md)                           | Enforce that the `license` property is valid.                                                     | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        |      |    |    | ❌  |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-bundleDependencies](docs/rules/valid-bundleDependencies.md)     | Enforce that the `bundleDependencies` (also: `bundledDependencies`) property is valid.            | ✔️ ✅ |    |    |    |
 | [valid-config](docs/rules/valid-config.md)                             | Enforce that the `config` property is valid.                                                      | ✔️ ✅ |    |    |    |
 | [valid-cpu](docs/rules/valid-cpu.md)                                   | Enforce that the `cpu` property is valid.                                                         | ✔️ ✅ |    |    |    |
+| [valid-dependencies](docs/rules/valid-dependencies.md)                 | Enforce that the `dependencies` property is valid.                                                | ✔️ ✅ |    |    |    |
 | [valid-license](docs/rules/valid-license.md)                           | Enforce that the `license` property is valid.                                                     | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        |      |    |    | ❌  |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |
 | [valid-optionalDependencies](docs/rules/valid-optionalDependencies.md) | Enforce that the `optionalDependencies` property is valid.                                        | ✔️ ✅ |    |    |    |
 | [valid-package-definition](docs/rules/valid-package-definition.md)     | Enforce that package.json has all properties required by the npm spec                             | ✔️ ✅ |    |    |    |
+| [valid-peerDependencies](docs/rules/valid-peerDependencies.md)         | Enforce that the `peerDependencies` property is valid.                                            | ✔️ ✅ |    |    |    |
 | [valid-repository-directory](docs/rules/valid-repository-directory.md) | Enforce that if repository directory is specified, it matches the path to the package.json file   | ✔️ ✅ |    | 💡 |    |
 | [valid-scripts](docs/rules/valid-scripts.md)                           | Enforce that the `scripts` property is valid.                                                     | ✔️ ✅ |    |    |    |
 | [valid-type](docs/rules/valid-type.md)                                 | Enforce that the `type` property is valid.                                                        | ✔️ ✅ |    |    |    |

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-license](docs/rules/valid-license.md)                           | Enforce that the `license` property is valid.                                                     | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)         | Checks existence of local dependencies in the package.json                                        |      |    |    | ❌  |
 | [valid-name](docs/rules/valid-name.md)                                 | Enforce that package names are valid npm package names                                            | ✔️ ✅ |    |    |    |
+| [valid-optionalDependencies](docs/rules/valid-optionalDependencies.md) | Enforce that the `optionalDependencies` property is valid.                                        | ✔️ ✅ |    |    |    |
 | [valid-package-definition](docs/rules/valid-package-definition.md)     | Enforce that package.json has all properties required by the npm spec                             | ✔️ ✅ |    |    |    |
 | [valid-repository-directory](docs/rules/valid-repository-directory.md) | Enforce that if repository directory is specified, it matches the path to the package.json file   | ✔️ ✅ |    | 💡 |    |
 | [valid-scripts](docs/rules/valid-scripts.md)                           | Enforce that the `scripts` property is valid.                                                     | ✔️ ✅ |    |    |    |

--- a/docs/rules/valid-dependencies.md
+++ b/docs/rules/valid-dependencies.md
@@ -1,0 +1,33 @@
+# valid-dependencies
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+The rule checks that, if present, the `dependencies` property is a validated according the following criteria:
+
+- The value is an object
+- Each property's key is a valid package name
+- Each property's value is a valid version range
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"dependencies": {
+		"invalid-version": "catalob:"
+	}
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"dependencies": {
+		"nin": "catalog:",
+		"thee-silver-mt-zion": "^1.2.3",
+		"david-bowie": "*"
+	}
+}
+```

--- a/docs/rules/valid-devDependencies.md
+++ b/docs/rules/valid-devDependencies.md
@@ -1,0 +1,33 @@
+# valid-devDependencies
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+The rule checks that, if present, the `devDependencies` property is a validated according the following criteria:
+
+- The value is an object
+- Each property's key is a valid package name
+- Each property's value is a valid version range
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"devDependencies": {
+		"invalid-version": "catalob:"
+	}
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"devDependencies": {
+		"nin": "catalog:",
+		"thee-silver-mt-zion": "^1.2.3",
+		"david-bowie": "*"
+	}
+}
+```

--- a/docs/rules/valid-optionalDependencies.md
+++ b/docs/rules/valid-optionalDependencies.md
@@ -1,0 +1,33 @@
+# valid-optionalDependencies
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+The rule checks that, if present, the `optionalDependencies` property is a validated according the following criteria:
+
+- The value is an object
+- Each property's key is a valid package name
+- Each property's value is a valid version range
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"optionalDependencies": {
+		"invalid-version": "catalob:"
+	}
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"optionalDependencies": {
+		"nin": "catalog:",
+		"thee-silver-mt-zion": "^1.2.3",
+		"david-bowie": "*"
+	}
+}
+```

--- a/docs/rules/valid-peerDependencies.md
+++ b/docs/rules/valid-peerDependencies.md
@@ -1,0 +1,33 @@
+# valid-peerDependencies
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+The rule checks that, if present, the `peerDependencies` property is a validated according the following criteria:
+
+- The value is an object
+- Each property's key is a valid package name
+- Each property's value is a valid version range
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"peerDependencies": {
+		"invalid-version": "catalob:"
+	}
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"peerDependencies": {
+		"nin": "catalog:",
+		"thee-silver-mt-zion": "^1.2.3",
+		"david-bowie": "*"
+	}
+}
+```

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"detect-indent": "^7.0.1",
 		"detect-newline": "^4.0.1",
 		"eslint-fix-utils": "~0.4.0",
-		"package-json-validator": "~0.24.1",
+		"package-json-validator": "~0.25.0",
 		"semver": "^7.5.4",
 		"sort-object-keys": "^1.1.3",
 		"sort-package-json": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ~0.4.0
         version: 0.4.0(@types/estree@1.0.7)(eslint@9.32.0(jiti@2.5.0))
       package-json-validator:
-        specifier: ~0.24.1
-        version: 0.24.1
+        specifier: ~0.25.0
+        version: 0.25.0
       semver:
         specifier: ^7.5.4
         version: 7.7.2
@@ -3183,8 +3183,8 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-json-validator@0.24.1:
-    resolution: {integrity: sha512-MTtImbS7Cn170JdSe/p2vxtNPtICZhs5P5npHOiDwEspD0F0FrI8krZ1N3t3tHGpMeZrMGSa5sdNH17hJHDwXQ==}
+  package-json-validator@0.25.0:
+    resolution: {integrity: sha512-9ddMcSXMvzIzK/EJBugvACgSTMFgoPwMGUiKuMqt/evdboJkFm1C9eX9KIJMegVh7y4bHG+USVokHqIRsdU3TQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7413,7 +7413,7 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  package-json-validator@0.24.1:
+  package-json-validator@0.25.0:
     dependencies:
       semver: 7.7.2
       validate-npm-package-license: 3.0.4

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -34,6 +34,7 @@ const properties = [
 	["config", validateConfig],
 	["cpu", validateCpu],
 	["dependencies", validateDependencies],
+	["devDependencies", validateDependencies],
 	["license", validateLicense],
 	["scripts", validateScripts],
 	["type", validateType],

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -3,6 +3,7 @@ import {
 	validateBundleDependencies,
 	validateConfig,
 	validateCpu,
+	validateDependencies,
 	validateLicense,
 	validateScripts,
 	validateType,
@@ -37,6 +38,7 @@ const properties = [
 	["devDependencies", validateDependencies],
 	["license", validateLicense],
 	["optionalDependencies", validateDependencies],
+	["peerDependencies", validateDependencies],
 	["scripts", validateScripts],
 	["type", validateType],
 	// TODO: More to come!

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -36,6 +36,7 @@ const properties = [
 	["dependencies", validateDependencies],
 	["devDependencies", validateDependencies],
 	["license", validateLicense],
+	["optionalDependencies", validateDependencies],
 	["scripts", validateScripts],
 	["type", validateType],
 	// TODO: More to come!

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -33,6 +33,7 @@ const properties = [
 	],
 	["config", validateConfig],
 	["cpu", validateCpu],
+	["dependencies", validateDependencies],
 	["license", validateLicense],
 	["scripts", validateScripts],
 	["type", validateType],

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -1,0 +1,106 @@
+import { rules } from "../../rules/valid-properties.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-dependencies", rules["valid-dependencies"], {
+	invalid: [
+		{
+			code: `{
+	"dependencies": null
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the field is `null`, but should be a record of dependencies",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"dependencies": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `number`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"dependencies": "./script.js"
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `string`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"dependencies": []
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `array`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"dependencies": {
+        "david": "bowie",
+        "trent": 123,
+        "the-fragile": null,
+        "pink-floyd": {},
+        "childish-gambino": "workspace"
+    }
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: `
+ - invalid version range for dependency david: bowie
+ - dependency version for trent should be a string: 123
+ - dependency version for the-fragile should be a string: null
+ - dependency version for pink-floyd should be a string: [object Object]
+ - invalid version range for dependency childish-gambino: workspace`,
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		`{
+  "dependencies": {
+    "silver-mt-zion": "^1.2.3",
+    "nin": "file:./nin",
+    "gybe": "catalog:",
+    "radiohead": "git+https://github.com/user/repo.git",
+    "sigur-ros": "https://example.com/sigur-ros.tgz",
+    "explosions-in-the-sky": "workspace:^",
+    "alt-j": "workspace:~",
+    "run-the-jewels": "workspace:*",
+    "thee-silver-mt-zion": "workspace:^1.2.3",
+    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+  }
+}`,
+		`{ "dependencies": {} }`,
+	],
+});

--- a/src/tests/rules/valid-devDependencies.test.ts
+++ b/src/tests/rules/valid-devDependencies.test.ts
@@ -1,0 +1,106 @@
+import { rules } from "../../rules/valid-properties.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-devDependencies", rules["valid-devDependencies"], {
+	invalid: [
+		{
+			code: `{
+	"devDependencies": null
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the field is `null`, but should be a record of dependencies",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"devDependencies": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `number`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"devDependencies": "./script.js"
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `string`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"devDependencies": []
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `array`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"devDependencies": {
+        "david": "bowie",
+        "trent": 123,
+        "the-fragile": null,
+        "pink-floyd": {},
+        "childish-gambino": "workspace"
+    }
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: `
+ - invalid version range for dependency david: bowie
+ - dependency version for trent should be a string: 123
+ - dependency version for the-fragile should be a string: null
+ - dependency version for pink-floyd should be a string: [object Object]
+ - invalid version range for dependency childish-gambino: workspace`,
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		`{
+  "devDependencies": {
+    "silver-mt-zion": "^1.2.3",
+    "nin": "file:./nin",
+    "gybe": "catalog:",
+    "radiohead": "git+https://github.com/user/repo.git",
+    "sigur-ros": "https://example.com/sigur-ros.tgz",
+    "explosions-in-the-sky": "workspace:^",
+    "alt-j": "workspace:~",
+    "run-the-jewels": "workspace:*",
+    "thee-silver-mt-zion": "workspace:^1.2.3",
+    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+  }
+}`,
+		`{ "devDependencies": {} }`,
+	],
+});

--- a/src/tests/rules/valid-optionalDependencies.test.ts
+++ b/src/tests/rules/valid-optionalDependencies.test.ts
@@ -1,0 +1,110 @@
+import { rules } from "../../rules/valid-properties.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run(
+	"valid-optionalDependencies",
+	rules["valid-optionalDependencies"],
+	{
+		invalid: [
+			{
+				code: `{
+	"optionalDependencies": null
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the field is `null`, but should be a record of dependencies",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"optionalDependencies": 123
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the type should be `object`, not `number`",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"optionalDependencies": "./script.js"
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the type should be `object`, not `string`",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"optionalDependencies": []
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: "the type should be `object`, not `array`",
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+			{
+				code: `{
+	"optionalDependencies": {
+        "david": "bowie",
+        "trent": 123,
+        "the-fragile": null,
+        "pink-floyd": {},
+        "childish-gambino": "workspace"
+    }
+}
+`,
+				errors: [
+					{
+						data: {
+							errors: `
+ - invalid version range for dependency david: bowie
+ - dependency version for trent should be a string: 123
+ - dependency version for the-fragile should be a string: null
+ - dependency version for pink-floyd should be a string: [object Object]
+ - invalid version range for dependency childish-gambino: workspace`,
+						},
+						messageId: "validationError",
+					},
+				],
+			},
+		],
+		valid: [
+			"{}",
+			`{
+  "optionalDependencies": {
+    "silver-mt-zion": "^1.2.3",
+    "nin": "file:./nin",
+    "gybe": "catalog:",
+    "radiohead": "git+https://github.com/user/repo.git",
+    "sigur-ros": "https://example.com/sigur-ros.tgz",
+    "explosions-in-the-sky": "workspace:^",
+    "alt-j": "workspace:~",
+    "run-the-jewels": "workspace:*",
+    "thee-silver-mt-zion": "workspace:^1.2.3",
+    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+  }
+}`,
+			`{ "optionalDependencies": {} }`,
+		],
+	},
+);

--- a/src/tests/rules/valid-peerDependencies.test.ts
+++ b/src/tests/rules/valid-peerDependencies.test.ts
@@ -1,0 +1,106 @@
+import { rules } from "../../rules/valid-properties.js";
+import { ruleTester } from "./ruleTester.js";
+
+ruleTester.run("valid-peerDependencies", rules["valid-peerDependencies"], {
+	invalid: [
+		{
+			code: `{
+	"peerDependencies": null
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the field is `null`, but should be a record of dependencies",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"peerDependencies": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `number`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"peerDependencies": "./script.js"
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `string`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"peerDependencies": []
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: "the type should be `object`, not `array`",
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"peerDependencies": {
+        "david": "bowie",
+        "trent": 123,
+        "the-fragile": null,
+        "pink-floyd": {},
+        "childish-gambino": "workspace"
+    }
+}
+`,
+			errors: [
+				{
+					data: {
+						errors: `
+ - invalid version range for dependency david: bowie
+ - dependency version for trent should be a string: 123
+ - dependency version for the-fragile should be a string: null
+ - dependency version for pink-floyd should be a string: [object Object]
+ - invalid version range for dependency childish-gambino: workspace`,
+					},
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		`{
+  "peerDependencies": {
+    "silver-mt-zion": "^1.2.3",
+    "nin": "file:./nin",
+    "gybe": "catalog:",
+    "radiohead": "git+https://github.com/user/repo.git",
+    "sigur-ros": "https://example.com/sigur-ros.tgz",
+    "explosions-in-the-sky": "workspace:^",
+    "alt-j": "workspace:~",
+    "run-the-jewels": "workspace:*",
+    "thee-silver-mt-zion": "workspace:^1.2.3",
+    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+  }
+}`,
+		`{ "peerDependencies": {} }`,
+	],
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: 
   - fixes #822 
   - fixes #824
   - fixes #833 
   - fixes #835 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change include four new rules, with each rule broken out by commit.  They're for all four flavors of `dependencies`:
- `valid-dependencies`
- `valid-devDependencies`
- `valid-optionalDependencies`
- `valid-peerDependencies`
