### PR TITLE
docs: fix mistake in new require rule docs

### DIFF
--- a/docs/rules/require-bugs.md
+++ b/docs/rules/require-bugs.md
@@ -32,7 +32,7 @@ You can set the `ignorePrivate` option to `true` to ignore package.json files wi
 
 ```json
 {
-	"package-json/require-author": [
+	"package-json/require-bugs": [
 		"error",
 		{
 			"ignorePrivate": false

--- a/docs/rules/require-bundleDependencies.md
+++ b/docs/rules/require-bundleDependencies.md
@@ -29,7 +29,7 @@ You can set the `ignorePrivate` option to `true` to ignore package.json files wi
 
 ```json
 {
-	"package-json/require-author": [
+	"package-json/require-bundleDependencies": [
 		"error",
 		{
 			"ignorePrivate": false

--- a/docs/rules/require-dependencies.md
+++ b/docs/rules/require-dependencies.md
@@ -31,7 +31,7 @@ You can set the `ignorePrivate` option to `true` to ignore package.json files wi
 
 ```json
 {
-	"package-json/require-author": [
+	"package-json/require-dependencies": [
 		"error",
 		{
 			"ignorePrivate": false

--- a/docs/rules/require-devDependencies.md
+++ b/docs/rules/require-devDependencies.md
@@ -31,7 +31,7 @@ You can set the `ignorePrivate` option to `true` to ignore package.json files wi
 
 ```json
 {
-	"package-json/require-author": [
+	"package-json/require-devDependencies": [
 		"error",
 		{
 			"ignorePrivate": false

--- a/docs/rules/require-optionalDependencies.md
+++ b/docs/rules/require-optionalDependencies.md
@@ -31,7 +31,7 @@ You can set the `ignorePrivate` option to `true` to ignore package.json files wi
 
 ```json
 {
-	"package-json/require-author": [
+	"package-json/require-optionalDependencies": [
 		"error",
 		{
 			"ignorePrivate": false

--- a/docs/rules/require-peerDependencies.md
+++ b/docs/rules/require-peerDependencies.md
@@ -31,7 +31,7 @@ You can set the `ignorePrivate` option to `true` to ignore package.json files wi
 
 ```json
 {
-	"package-json/require-author": [
+	"package-json/require-peerDependencies": [
 		"error",
 		{
 			"ignorePrivate": false


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Coming from https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/pull/1158, after fixing the merge conflict and correcting the docs errors for the PR author (due to me creating the conflict 😬), I realized I didn't update the rule name in these docs when bringing the over from the other rules.
