### PR TITLE
fix(sort-collections): align sorting of scripts with `prettier-plugin-packagejson`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"*": "prettier --ignore-unknown --write"
 	},
 	"dependencies": {
-		"@altano/repository-tools": "^2.0.0",
+		"@altano/repository-tools": "^2.0.1",
 		"change-case": "^5.4.4",
 		"detect-indent": "^7.0.1",
 		"detect-newline": "^4.0.1",
@@ -52,8 +52,8 @@
 		"package-json-validator": "~0.25.0",
 		"semver": "^7.5.4",
 		"sort-object-keys": "^1.1.3",
-		"sort-package-json": "^3.0.0",
-		"validate-npm-package-name": "^6.0.0"
+		"sort-package-json": "^3.3.0",
+		"validate-npm-package-name": "^6.0.2"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     dependencies:
       '@altano/repository-tools':
-        specifier: ^2.0.0
+        specifier: ^2.0.1
         version: 2.0.1
       change-case:
         specifier: ^5.4.4
@@ -33,11 +33,11 @@ importers:
         specifier: ^1.1.3
         version: 1.1.3
       sort-package-json:
-        specifier: ^3.0.0
+        specifier: ^3.3.0
         version: 3.4.0
       validate-npm-package-name:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^6.0.2
+        version: 6.0.2
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.5.0
@@ -3921,8 +3921,8 @@ packages:
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
 
-  validate-npm-package-name@6.0.0:
-    resolution: {integrity: sha512-d7KLgL1LD3U3fgnvWEY1cQXoO/q6EQ1BSz48Sa149V/5zVTAbgmZIpyI8TRi6U9/JNyeYLlTKsEMPtLC27RFUg==}
+  validate-npm-package-name@6.0.2:
+    resolution: {integrity: sha512-IUoow1YUtvoBBC06dXs8bR8B9vuA3aJfmQNKMoaPG/OFsPmoQvw8xh+6Ye25Gx9DQhoEom3Pcu9MKHerm/NpUQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
   vite-node@3.2.0:
@@ -8161,7 +8161,7 @@ snapshots:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
 
-  validate-npm-package-name@6.0.0: {}
+  validate-npm-package-name@6.0.2: {}
 
   vite-node@3.2.0(@types/node@22.17.0)(jiti@2.5.0)(yaml@2.8.0):
     dependencies:

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -123,6 +123,28 @@ ruleTester.run("sort-collections", rule, {
 		},
 		{
 			code: `{
+	"scripts": {
+		"postinstall": "echo test",
+		"preinstall": "echo test"
+	}
+}`,
+			errors: [
+				{
+					data: { key: "scripts" },
+					messageId: "notAlphabetized",
+					type: "JSONProperty",
+				},
+			],
+			filename: "package.json",
+			output: `{
+	"scripts": {
+    "preinstall": "echo test",
+    "postinstall": "echo test"
+  }
+}`,
+		},
+		{
+			code: `{
 	"exports": {
 		"./package.json": "./package.json",
 		".": {
@@ -269,6 +291,14 @@ ruleTester.run("sort-collections", rule, {
         "prebuild": "echo test",
 		"build": "echo test",
         "postbuild": "echo test"
+	}
+}`,
+		},
+		{
+			code: `{
+	"scripts": {
+        "preinstall": "echo test",
+        "postinstall": "echo test"
 	}
 }`,
 		},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #753 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates how we're sorting script properties in `sort-collections`, to align with how  `prettier-plugin-packagejson` sorts it.  The main gap in what we had in our bespoke implementation and what we have now, is that pre/post lifecycle scripts were not being grouped together if the non-prefixed version of the script was not also included.  For example, it's rare to have an `install` script in a package.json, but super common to have a `postinstall`.  Now `preinstall` and `postinstall` are sorted correctly in the place where `install` would normally be sorted, with `preinstall` coming first and `postinstall` coming second.

In order to achieve this, I replaced the bespoke script sorting implementation with a call to `sort-package-json`, which is what the prettier plugin also uses to sort.
