### PR TITLE
build: change relative import extensions to ts

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -5,7 +5,7 @@ name: Prepare
 inputs:
   node-version:
     description: "Node.js version to use"
-    default: "20"
+    default: "lts/*"
     required: false
 
 runs:

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -11,7 +11,7 @@ import * as regexp from "eslint-plugin-regexp";
 import yml from "eslint-plugin-yml";
 import tseslint from "typescript-eslint";
 
-import packageJson from "./src/index.js";
+import packageJson from "./src/index.ts";
 
 export default tseslint.config(
 	{

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"lib/"
 	],
 	"scripts": {
-		"build": "tsup",
+		"build": "tsdown",
 		"build:docs": "pnpm build --no-dts && eslint-doc-generator",
 		"format": "prettier .",
 		"lint": "eslint . --max-warnings 0",
@@ -92,7 +92,7 @@
 		"prettier-plugin-sh": "0.18.0",
 		"release-it": "19.0.1",
 		"sentences-per-line": "0.3.0",
-		"tsup": "8.5.0",
+		"tsdown": "^0.13.3",
 		"typescript": "5.9.2",
 		"typescript-eslint": "8.38.0",
 		"vitest": "3.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,34 +173,17 @@ packages:
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.25.7':
-    resolution: {integrity: sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.28.0':
     resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@7.25.9':
-    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@7.25.9':
-    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/parser@7.27.0':
-    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.28.0':
     resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
@@ -213,10 +196,6 @@ packages:
 
   '@babel/traverse@7.25.7':
     resolution: {integrity: sha512-jatJPT1Zjqvh/1FyJs6qAHL+Dzb7sTb+xr7Q+gM1b+1oBsMsQQ4FkVKb6dFlJvLlVssqkRzV05Jzervt9yhnzg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.27.0':
-    resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.28.2':
@@ -464,20 +443,11 @@ packages:
     resolution: {integrity: sha512-PMJBuLYQIdFnEfPHQXaVE5hHUkbbOxOIRmHyZwWEc9+79tIaIkiwLpjZvbm8p6f9WXAaESqXs/uK2tUC/bjwmw==}
     engines: {node: '>=20'}
 
-  '@emnapi/core@1.4.3':
-    resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
-
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
 
-  '@emnapi/runtime@1.4.3':
-    resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
-
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
-
-  '@emnapi/wasi-threads@1.0.2':
-    resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
 
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
@@ -840,23 +810,12 @@ packages:
   '@jridgewell/gen-mapping@0.3.12':
     resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
 
-  '@jridgewell/gen-mapping@0.3.8':
-    resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/set-array@1.2.1':
-    resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
-    engines: {node: '>=6.0.0'}
-
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
@@ -2429,9 +2388,6 @@ packages:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
 
-  get-tsconfig@4.10.0:
-    resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
-
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
@@ -2920,7 +2876,6 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
-    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -4225,21 +4180,14 @@ snapshots:
 
   '@ampproject/remapping@2.3.0':
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
 
   '@babel/code-frame@7.26.2':
     dependencies:
-      '@babel/helper-validator-identifier': 7.25.9
+      '@babel/helper-validator-identifier': 7.27.1
       js-tokens: 4.0.0
       picocolors: 1.1.1
-
-  '@babel/generator@7.25.7':
-    dependencies:
-      '@babel/types': 7.27.0
-      '@jridgewell/gen-mapping': 0.3.8
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 3.0.2
 
   '@babel/generator@7.28.0':
     dependencies:
@@ -4249,17 +4197,9 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.29
       jsesc: 3.0.2
 
-  '@babel/helper-string-parser@7.25.9': {}
-
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.25.9': {}
-
   '@babel/helper-validator-identifier@7.27.1': {}
-
-  '@babel/parser@7.27.0':
-    dependencies:
-      '@babel/types': 7.27.0
 
   '@babel/parser@7.28.0':
     dependencies:
@@ -4268,25 +4208,20 @@ snapshots:
   '@babel/template@7.25.7':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
 
   '@babel/traverse@7.25.7':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@babel/generator': 7.25.7
-      '@babel/parser': 7.27.0
+      '@babel/generator': 7.28.0
+      '@babel/parser': 7.28.0
       '@babel/template': 7.25.7
-      '@babel/types': 7.27.0
+      '@babel/types': 7.28.2
       debug: 4.4.1
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.27.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.25.9
-      '@babel/helper-validator-identifier': 7.25.9
 
   '@babel/types@7.28.2':
     dependencies:
@@ -4525,29 +4460,13 @@ snapshots:
 
   '@cspell/url@9.1.2': {}
 
-  '@emnapi/core@1.4.3':
-    dependencies:
-      '@emnapi/wasi-threads': 1.0.2
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.4.5':
     dependencies:
       '@emnapi/wasi-threads': 1.0.4
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.4.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.4.5':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.0.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4841,22 +4760,9 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.29
 
-  '@jridgewell/gen-mapping@0.3.8':
-    dependencies:
-      '@jridgewell/set-array': 1.2.1
-      '@jridgewell/sourcemap-codec': 1.5.0
-      '@jridgewell/trace-mapping': 0.3.25
-
   '@jridgewell/resolve-uri@3.1.2': {}
 
-  '@jridgewell/set-array@1.2.1': {}
-
   '@jridgewell/sourcemap-codec@1.5.0': {}
-
-  '@jridgewell/trace-mapping@0.3.25':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
 
   '@jridgewell/trace-mapping@0.3.29':
     dependencies:
@@ -4865,8 +4771,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
-      '@emnapi/core': 1.4.3
-      '@emnapi/runtime': 1.4.3
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
       '@tybys/wasm-util': 0.9.0
     optional: true
 
@@ -5558,7 +5464,7 @@ snapshots:
 
   ast-v8-to-istanbul@0.3.3:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
@@ -6311,7 +6217,7 @@ snapshots:
       enhanced-resolve: 5.18.1
       eslint: 9.32.0(jiti@2.5.0)
       eslint-plugin-es-x: 7.8.0(eslint@9.32.0(jiti@2.5.0))
-      get-tsconfig: 4.10.0
+      get-tsconfig: 4.10.1
       globals: 15.15.0
       ignore: 5.3.2
       minimatch: 9.0.5
@@ -6587,10 +6493,6 @@ snapshots:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
       is-stream: 4.0.1
-
-  get-tsconfig@4.10.0:
-    dependencies:
-      resolve-pkg-maps: 1.0.0
 
   get-tsconfig@4.10.1:
     dependencies:
@@ -6928,7 +6830,7 @@ snapshots:
 
   istanbul-lib-source-maps@5.0.6:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
+      '@jridgewell/trace-mapping': 0.3.29
       debug: 4.4.1
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
@@ -7117,8 +7019,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.0
-      '@babel/types': 7.27.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -7752,8 +7654,8 @@ snapshots:
 
   prettier-plugin-curly@0.3.1(prettier@3.6.0):
     dependencies:
-      '@babel/generator': 7.25.7
-      '@babel/parser': 7.27.0
+      '@babel/generator': 7.28.0
+      '@babel/parser': 7.28.0
       '@babel/traverse': 7.25.7
       prettier: 3.6.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,9 +147,9 @@ importers:
       sentences-per-line:
         specifier: 0.3.0
         version: 0.3.0
-      tsup:
-        specifier: 8.5.0
-        version: 8.5.0(jiti@2.5.0)(postcss@8.5.3)(typescript@5.9.2)(yaml@2.8.0)
+      tsdown:
+        specifier: ^0.13.3
+        version: 0.13.3(oxc-resolver@11.2.0)(typescript@5.9.2)
       typescript:
         specifier: 5.9.2
         version: 5.9.2
@@ -177,16 +177,33 @@ packages:
     resolution: {integrity: sha512-5Dqpl5fyV9pIAD62yK9P7fcA768uVPUyrQmqpqstHWgMma4feF1x/oFysBCVZLY5wJ2GkMUCdsNDnGZrPoR6rA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/generator@7.28.0':
+    resolution: {integrity: sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.25.9':
     resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.25.9':
     resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.27.1':
+    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.27.0':
     resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.28.0':
+    resolution: {integrity: sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -200,6 +217,10 @@ packages:
 
   '@babel/types@7.27.0':
     resolution: {integrity: sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -446,11 +467,20 @@ packages:
   '@emnapi/core@1.4.3':
     resolution: {integrity: sha512-4m62DuCE07lw01soJwPiBGC0nAww0Q+RY70VZ+n49yDIO13yyinhbWCeNnaob0lakDtWQzSdtNWzJeOJt2ma+g==}
 
+  '@emnapi/core@1.4.5':
+    resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
+
   '@emnapi/runtime@1.4.3':
     resolution: {integrity: sha512-pBPWdu6MLKROBX05wSNKcNb++m5Er+KQ9QkB+WVM+pW2Kx9hoSrVTnu3BdkI5eBLZoKu/J6mW/B6i6bJB2ytXQ==}
 
+  '@emnapi/runtime@1.4.5':
+    resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
+
   '@emnapi/wasi-threads@1.0.2':
     resolution: {integrity: sha512-5n3nTJblwRi8LlXkJ9eBzu+kZR8Yxcc7ubakyQTFzPMtIhFpUBRbsnc2Dv88IZDIbCDlBiWrknhB4Lsz7mg6BA==}
+
+  '@emnapi/wasi-threads@1.0.4':
+    resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
 
   '@es-joy/jsdoccomment@0.52.0':
     resolution: {integrity: sha512-BXuN7BII+8AyNtn57euU2Yxo9yA/KUDNzrpXyi3pfqKmBhhysR6ZWOebFh3vyPoqA3/j1SOvGgucElMGwlXing==}
@@ -807,6 +837,9 @@ packages:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.12':
+    resolution: {integrity: sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==}
+
   '@jridgewell/gen-mapping@0.3.8':
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
@@ -825,8 +858,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
+  '@jridgewell/trace-mapping@0.3.29':
+    resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
+
+  '@napi-rs/wasm-runtime@1.0.2':
+    resolution: {integrity: sha512-4pSAVWEyZMgE9q+SYkHK+UhYRo4o7P+NYZSsuuhU0wKNzV09ujaxerrbzgv6zyLoWIggJb8ql/KRzv0H9WuAZQ==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -963,6 +1002,13 @@ packages:
   '@one-ini/wasm@0.2.0':
     resolution: {integrity: sha512-n+L/BvrwKUn7q5O3wHGo+CJZAqfewh38+37sk+eBzv/39lM9pPgPRd4sOZRvSRzo0ukLxzyXso4WlGj2oKZ5hA==}
 
+  '@oxc-project/runtime@0.80.0':
+    resolution: {integrity: sha512-3rzy1bJAZ4s7zV9TKT60x119RwJDCDqEtCwK/Zc2qlm7wGhiIUxLLYUhE/mN91yB0u1kxm5sh4NjU12sPqQTpg==}
+    engines: {node: '>=6.9.0'}
+
+  '@oxc-project/types@0.80.0':
+    resolution: {integrity: sha512-xxHQm8wfCv2e8EmtaDwpMeAHOWqgQDAYg+BJouLXSQt5oTKu9TIXrgNMGSrM2fLvKmECsRd9uUFAAD+hPyootA==}
+
   '@oxc-resolver/binding-darwin-arm64@11.2.0':
     resolution: {integrity: sha512-ruKLkS+Dm/YIJaUhzEB7zPI+jh3EXxu0QnNV8I7t9jf0lpD2VnltuyRbhrbJEkksklZj//xCMyFFsILGjiU2Mg==}
     cpu: [arm64]
@@ -1040,6 +1086,10 @@ packages:
     resolution: {integrity: sha512-fdDH1LSGfZdTH2sxdpVMw31BanV28K/Gry0cVFxaNP77neJSkd82mM8ErPNYs9e+0O7SdHBLTDzDgwUuy18RnQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@quansync/fs@0.1.3':
+    resolution: {integrity: sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==}
+    engines: {node: '>=20.0.0'}
+
   '@release-it/conventional-changelog@10.0.0':
     resolution: {integrity: sha512-49qf9phGmPUIGpY2kwfgehs9en1znbPv2zdNn1WMLAH9DtHUh4m6KNSB+mLFGAMUhv24JhsA8ruYRYgluc2UJw==}
     engines: {node: ^20.9.0 || >=22.0.0}
@@ -1049,6 +1099,79 @@ packages:
   '@reteps/dockerfmt@0.3.6':
     resolution: {integrity: sha512-Tb5wIMvBf/nLejTQ61krK644/CEMB/cpiaIFXqGApfGqO3GwcR3qnI0DbmkFVCl2OyEp8LnLX3EkucoL0+tbFg==}
     engines: {node: ^v12.20.0 || ^14.13.0 || >=16.0.0}
+
+  '@rolldown/binding-android-arm64@1.0.0-beta.31':
+    resolution: {integrity: sha512-0mFtKwOG7smn0HkvQ6h8j0m/ohkR7Fp5eMTJ2Pns/HSbePHuDpxMaQ4TjZ6arlVXxpeWZlAHeT5BeNsOA3iWTg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.31':
+    resolution: {integrity: sha512-BHfHJ8Nb5G7ZKJl6pimJacupONT4F7w6gmQHw41rouAnJF51ORDwGefWeb6OMLzGmJwzxlIVPERfnJf1EsMM7A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.31':
+    resolution: {integrity: sha512-4MiuRtExC08jHbSU/diIL+IuQP+3Ck1FbWAplK+ysQJ7fxT3DMxy5FmnIGfmhaqow8oTjb2GEwZJKgTRjZL1Vw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.31':
+    resolution: {integrity: sha512-nffC1u7ccm12qlAea8ExY3AvqlaHy/o/3L4p5Es8JFJ3zJSs6e3DyuxGZZVdl9EVwsLxPPTvioIl4tEm2afwyw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.31':
+    resolution: {integrity: sha512-LHmAaB3rB1GOJuHscKcL2Ts/LKLcb3YWTh2uQ/876rg/J9WE9kQ0kZ+3lRSYbth/YL8ln54j4JZmHpqQY3xptQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.31':
+    resolution: {integrity: sha512-oTDZVfqIAjLB2I1yTiLyyhfPPO6dky33sTblxTCpe+ZT55WizN3KDoBKJ4yXG8shI6I4bRShVu29Xg0yAjyQYw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.31':
+    resolution: {integrity: sha512-duJ3IkEBj9Xe9NYW1n8Y3483VXHGi8zQ0ZsLbK8464EJUXLF7CXM8Ry+jkkUw+ZvA+Zu1E/+C6p2Y6T9el0C9g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.31':
+    resolution: {integrity: sha512-qdbmU5QSZ0uoLZBYMxiHsMQmizqtzFGTVPU5oyU1n0jU0Mo+mkSzqZuL8VBnjHOHzhVxZsoAGH9JjiRzCnoGVA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.31':
+    resolution: {integrity: sha512-H7+r34TSV8udB2gAsebFM/YuEeNCkPGEAGJ1JE7SgI9XML6FflqcdKfrRSneQFsPaom/gCEc1g0WW5MZ0O3blw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.31':
+    resolution: {integrity: sha512-zRm2YmzFVqbsmUsyyZnHfJrOlQUcWS/FJ5ZWL8Q1kZh5PnLBrTVZNpakIWwAxpN5gNEi9MmFd5YHocVJp8ps1Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.31':
+    resolution: {integrity: sha512-fM1eUIuHLsNJXRlWOuIIex1oBJ89I0skFWo5r/D3KSJ5gD9MBd3g4Hp+v1JGohvyFE+7ylnwRxSUyMEeYpA69A==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.31':
+    resolution: {integrity: sha512-4nftR9V2KHH3zjBwf6leuZZJQZ7v0d70ogjHIqB3SDsbDLvVEZiGSsSn2X6blSZRZeJSFzK0pp4kZ67zdZXwSw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.31':
+    resolution: {integrity: sha512-0TQcKu9xZVHYALit+WJsSuADGlTFfOXhnZoIHWWQhTk3OgbwwbYcSoZUXjRdFmR6Wswn4csHtJGN1oYKeQ6/2g==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.31':
+    resolution: {integrity: sha512-3zMICWwpZh1jrkkKDYIUCx/2wY3PXLICAS0AnbeLlhzfWPhCcpNK9eKhiTlLAZyTp+3kyipoi/ZSVIh+WDnBpQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-beta.31':
+    resolution: {integrity: sha512-IaDZ9NhjOIOkYtm+hH0GX33h3iVZ2OeSUnFF0+7Z4+1GuKs4Kj5wK3+I2zNV9IPLfqV4XlwWif8SXrZNutxciQ==}
 
   '@rollup/rollup-android-arm-eabi@4.39.0':
     resolution: {integrity: sha512-lGVys55Qb00Wvh8DMAocp5kIcaNzEFTmGhfFd88LfaogYTRKrdxgtlO5H6S49v2Nd8R2C6wLOal0qv6/kCkOwA==}
@@ -1181,6 +1304,9 @@ packages:
 
   '@tootallnate/quickjs-emscripten@0.23.0':
     resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@tybys/wasm-util@0.10.0':
+    resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
@@ -1409,8 +1535,9 @@ packages:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
 
-  any-promise@1.3.0:
-    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+  ansis@4.1.0:
+    resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
+    engines: {node: '>=14'}
 
   are-docs-informative@0.0.2:
     resolution: {integrity: sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==}
@@ -1436,6 +1563,10 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  ast-kit@2.1.1:
+    resolution: {integrity: sha512-mfh6a7gKXE8pDlxTvqIc/syH/P3RkzbOF6LeHdcKztLEzYe6IMsRCL7N8vI7hqTGWNxpkCuuRTpT21xNWqhRtQ==}
+    engines: {node: '>=20.18.0'}
 
   ast-types@0.13.4:
     resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
@@ -1487,6 +1618,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  birpc@2.5.0:
+    resolution: {integrity: sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
@@ -1509,12 +1643,6 @@ packages:
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
-
-  bundle-require@5.1.0:
-    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.18'
 
   c12@3.0.3:
     resolution: {integrity: sha512-uC3MacKBb0Z15o5QWCHvHWj5Zv34pGQj9P+iXKSpTuSGFS0KKhUWf4t9AJ+gWjYOdmWCPEGpEzm8sS0iqbpo1w==}
@@ -1644,10 +1772,6 @@ packages:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
     engines: {node: '>=20'}
 
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-
   commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
@@ -1669,9 +1793,6 @@ packages:
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
-
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
@@ -1899,6 +2020,10 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  diff@8.0.2:
+    resolution: {integrity: sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==}
+    engines: {node: '>=0.3.1'}
+
   dir-glob@2.2.2:
     resolution: {integrity: sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==}
     engines: {node: '>=4'}
@@ -1928,6 +2053,15 @@ packages:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
 
+  dts-resolver@2.1.1:
+    resolution: {integrity: sha512-3BiGFhB6mj5Kv+W2vdJseQUYW+SKVzAFJL6YNP6ursbrwy1fXHRotfHi3xLNxe4wZl/K8qbAFeCDjZLjzqxxRw==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      oxc-resolver: '>=11.0.0'
+    peerDependenciesMeta:
+      oxc-resolver:
+        optional: true
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -1944,6 +2078,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
 
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -2231,9 +2369,6 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  fix-dts-default-cjs-exports@1.0.1:
-    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
-
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -2296,6 +2431,9 @@ packages:
 
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
+
+  get-tsconfig@4.10.1:
+    resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
 
   get-uri@6.0.4:
     resolution: {integrity: sha512-E1b1lFFLvLgak2whF2xDBcOy6NLVGZBqqjJjsIhvopKfWWEi64pLVTWWehV8KlLerZkfNTA95sTe2OdJKm1OzQ==}
@@ -2394,6 +2532,9 @@ packages:
   hash-object@5.0.1:
     resolution: {integrity: sha512-iaRY4jYOow1caHkXW7wotYRjZDQk2nq4U7904anGJj8l4x1SLId+vuR8RpGoywZz9puD769hNFVFLFH9t+baJw==}
     engines: {node: '>=18'}
+
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
 
   hosted-git-info@7.0.2:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
@@ -2662,10 +2803,6 @@ packages:
     resolution: {integrity: sha512-NWDAhdnATItTnRhip9VTd8oXDjVcbhetRN6YzckApnXGxpGUooKMAaf0KVvlZG0+KlJMGkeLElVn4M1ReuxKUQ==}
     hasBin: true
 
-  joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -2771,10 +2908,6 @@ packages:
     resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
     engines: {node: '>=18.0.0'}
 
-  load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
@@ -2797,9 +2930,6 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  lodash.sortby@4.7.0:
-    resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
 
   lodash.uniqby@4.7.0:
     resolution: {integrity: sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==}
@@ -3008,9 +3138,6 @@ packages:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
-  mlly@1.7.4:
-    resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
-
   mount-point@3.0.0:
     resolution: {integrity: sha512-jAhfD7ZCG+dbESZjcY1SdFVFqSJkh/yGbdsifHcPkvuLRO5ugK0Ssmd9jdATu29BTd4JiN+vkpMzVvsUgP3SZA==}
     engines: {node: '>=0.10.0'}
@@ -3025,9 +3152,6 @@ packages:
   mute-stream@2.0.0:
     resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
     engines: {node: ^18.17.0 || >=20.5.0}
-
-  mz@2.7.0:
-    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
   nano-spawn@1.0.2:
     resolution: {integrity: sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==}
@@ -3094,10 +3218,6 @@ packages:
     resolution: {integrity: sha512-mn8wBFV9G9+UFHIrq+pZ2r2zL4aPau/by3kJb3cM7+5tQHMt6HGQB8FDIeKFYp8o0D2pnH6nVsO88N4AmUxIWg==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
-
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
-    engines: {node: '>=0.10.0'}
 
   object-strings-deep@0.1.2:
     resolution: {integrity: sha512-k5EsgxZzN+ktO5NqFP1cFf957Ajp98lT4zhN/skEm+o/8wi4XtUGPUFoRRmW7t1Gisksjtpzra2UcyWLzR4gdA==}
@@ -3320,33 +3440,8 @@ packages:
     resolution: {integrity: sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==}
     engines: {node: '>=0.10.0'}
 
-  pirates@4.0.6:
-    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
-    engines: {node: '>= 6'}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
-
   pkg-types@2.1.0:
     resolution: {integrity: sha512-wmJwA+8ihJixSoHKxZJRBQG1oY8Yr9pGLzRmSsNms0iNWyHHAlZCa7mmKiFR10YPZuz/2k169JiS/inOjBCZ2A==}
-
-  postcss-load-config@6.0.1:
-    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-      postcss:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -3409,6 +3504,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  quansync@0.2.10:
+    resolution: {integrity: sha512-t41VRkMYbkHyCYmOvx/6URnN80H7k4X0lLdBMGsz+maAwrJQYB1djpV6vHrQIBE0WBSGqhtEHrK9U3DWWH8v7A==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -3490,6 +3588,26 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rolldown-plugin-dts@0.15.5:
+    resolution: {integrity: sha512-YlgrK2oihea16LNXG0nUaNkb82SvbOmyhKpoid1M4Wehz6Bqkw1ZfZrUaBubIAt9M1up/Ku5EArGh7OSqA3tKA==}
+    engines: {node: '>=20.18.0'}
+    peerDependencies:
+      '@typescript/native-preview': '>=7.0.0-dev.20250601.1'
+      rolldown: ^1.0.0-beta.9
+      typescript: ^5.0.0
+      vue-tsc: ~3.0.3
+    peerDependenciesMeta:
+      '@typescript/native-preview':
+        optional: true
+      typescript:
+        optional: true
+      vue-tsc:
+        optional: true
+
+  rolldown@1.0.0-beta.31:
+    resolution: {integrity: sha512-M2Q+RfG0FMJeSW3RSFTbvtjGVTcQpTQvN247D0EMSsPkpZFoinopR9oAnQiwgogQyzDuvKNnbyCbQQlmNAzSoQ==}
+    hasBin: true
 
   rollup@4.39.0:
     resolution: {integrity: sha512-thI8kNc02yNvnmJp8dr3fNWJ9tCONDhp6TV35X6HkKGGs9E6q7YWCHbe5vKiTa7TAiNcFEmXKj3X/pG2b3ci0g==}
@@ -3627,11 +3745,6 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.8.0-beta.0:
-    resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
-    engines: {node: '>= 8'}
-    deprecated: The work that was done in this beta branch won't be included in future versions
-
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -3707,11 +3820,6 @@ packages:
     resolution: {integrity: sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==}
     engines: {node: '>=14.16'}
 
-  sucrase@3.35.0:
-    resolution: {integrity: sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3731,13 +3839,6 @@ packages:
   test-exclude@7.0.1:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
-
-  thenify-all@1.6.0:
-    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
-    engines: {node: '>=0.8'}
-
-  thenify@3.3.1:
-    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
   throttled-queue@2.1.4:
     resolution: {integrity: sha512-YGdk8sdmr4ge3g+doFj/7RLF5kLM+Mi7DEciu9PHxnMJZMeVuZeTj31g4VE7ekUffx/IdbvrtOCiz62afg0mkg==}
@@ -3786,9 +3887,6 @@ packages:
     resolution: {integrity: sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==}
     engines: {node: '>=12'}
 
-  tr46@1.0.1:
-    resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-
   trash-cli@6.0.0:
     resolution: {integrity: sha512-O97EQwg5kHd18GvV6BnMvAlfsMsZC+mhQZH04HFalB5U9hgFDjcLQXALZ62cf4c+jKB2F3pAhQQTkUoiURGCqg==}
     engines: {node: '>=18'}
@@ -3813,30 +3911,30 @@ packages:
     peerDependencies:
       typescript: '>=4.0.0'
 
-  ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tsup@8.5.0:
-    resolution: {integrity: sha512-VmBp77lWNQq6PfuMqCHD3xWl22vEoWsKajkF8t+yMBawlUS8JzEI+vOVMeuNZIuMML8qXRizFKi9oD5glKQVcQ==}
-    engines: {node: '>=18'}
+  tsdown@0.13.3:
+    resolution: {integrity: sha512-3ujweLJB70DdWXX3v7xnzrFhzW1F/6/99XhGeKzh1UCmZ+ttFmF7Czha7VaunA5Dq/u+z4aNz3n4GH748uivYg==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
     peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
+      '@arethetypeswrong/core': ^0.18.1
+      publint: ^0.3.0
+      typescript: ^5.0.0
+      unplugin-lightningcss: ^0.4.0
+      unplugin-unused: ^0.5.0
     peerDependenciesMeta:
-      '@microsoft/api-extractor':
+      '@arethetypeswrong/core':
         optional: true
-      '@swc/core':
-        optional: true
-      postcss:
+      publint:
         optional: true
       typescript:
         optional: true
+      unplugin-lightningcss:
+        optional: true
+      unplugin-unused:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3872,13 +3970,13 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  ufo@1.6.1:
-    resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
-
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
     engines: {node: '>=0.8.0'}
     hasBin: true
+
+  unconfig@7.3.2:
+    resolution: {integrity: sha512-nqG5NNL2wFVGZ0NA/aCFw0oJ2pxSf1lwg4Z5ill8wd7K4KX/rQbHlwbh+bjctXL5Ly1xtzHenHGOK0b+lG6JVg==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4007,12 +4105,6 @@ packages:
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
     engines: {node: 20 || >=22}
-
-  webidl-conversions@4.0.2:
-    resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
-
-  whatwg-url@7.1.0:
-    resolution: {integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4149,13 +4241,29 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 3.0.2
 
+  '@babel/generator@7.28.0':
+    dependencies:
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
+      '@jridgewell/gen-mapping': 0.3.12
+      '@jridgewell/trace-mapping': 0.3.29
+      jsesc: 3.0.2
+
   '@babel/helper-string-parser@7.25.9': {}
 
+  '@babel/helper-string-parser@7.27.1': {}
+
   '@babel/helper-validator-identifier@7.25.9': {}
+
+  '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/parser@7.27.0':
     dependencies:
       '@babel/types': 7.27.0
+
+  '@babel/parser@7.28.0':
+    dependencies:
+      '@babel/types': 7.28.2
 
   '@babel/template@7.25.7':
     dependencies:
@@ -4179,6 +4287,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
+
+  '@babel/types@7.28.2':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.27.1
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -4418,12 +4531,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.4.5':
+    dependencies:
+      '@emnapi/wasi-threads': 1.0.4
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.4.5':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.0.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.0.4':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -4707,6 +4836,11 @@ snapshots:
     dependencies:
       '@sinclair/typebox': 0.27.8
 
+  '@jridgewell/gen-mapping@0.3.12':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.29
+
   '@jridgewell/gen-mapping@0.3.8':
     dependencies:
       '@jridgewell/set-array': 1.2.1
@@ -4724,11 +4858,23 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@jridgewell/trace-mapping@0.3.29':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
       '@emnapi/core': 1.4.3
       '@emnapi/runtime': 1.4.3
       '@tybys/wasm-util': 0.9.0
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.0.2':
+    dependencies:
+      '@emnapi/core': 1.4.5
+      '@emnapi/runtime': 1.4.5
+      '@tybys/wasm-util': 0.10.0
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -4907,6 +5053,10 @@ snapshots:
 
   '@one-ini/wasm@0.2.0': {}
 
+  '@oxc-project/runtime@0.80.0': {}
+
+  '@oxc-project/types@0.80.0': {}
+
   '@oxc-resolver/binding-darwin-arm64@11.2.0':
     optional: true
 
@@ -4955,6 +5105,10 @@ snapshots:
 
   '@pkgr/core@0.1.2': {}
 
+  '@quansync/fs@0.1.3':
+    dependencies:
+      quansync: 0.2.10
+
   '@release-it/conventional-changelog@10.0.0(conventional-commits-filter@5.0.0)(conventional-commits-parser@6.1.0)(release-it@19.0.1(@types/node@22.17.0)(magicast@0.3.5))':
     dependencies:
       concat-stream: 2.0.0
@@ -4968,6 +5122,52 @@ snapshots:
       - conventional-commits-parser
 
   '@reteps/dockerfmt@0.3.6': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-ohos@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-beta.31':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.0.2
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-win32-ia32-msvc@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-beta.31':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-beta.31': {}
 
   '@rollup/rollup-android-arm-eabi@4.39.0':
     optional: true
@@ -5051,6 +5251,11 @@ snapshots:
   '@stroncium/procfs@1.2.1': {}
 
   '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@tybys/wasm-util@0.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@tybys/wasm-util@0.9.0':
     dependencies:
@@ -5324,7 +5529,7 @@ snapshots:
 
   ansi-styles@6.2.1: {}
 
-  any-promise@1.3.0: {}
+  ansis@4.1.0: {}
 
   are-docs-informative@0.0.2: {}
 
@@ -5341,6 +5546,11 @@ snapshots:
   array-uniq@1.0.3: {}
 
   assertion-error@2.0.1: {}
+
+  ast-kit@2.1.1:
+    dependencies:
+      '@babel/parser': 7.28.0
+      pathe: 2.0.3
 
   ast-types@0.13.4:
     dependencies:
@@ -5411,6 +5621,8 @@ snapshots:
       without-undefined-properties: 0.1.2
       zod: 3.25.71
 
+  birpc@2.5.0: {}
+
   boolbase@1.0.0: {}
 
   bottleneck@2.19.5: {}
@@ -5433,11 +5645,6 @@ snapshots:
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.0.0
-
-  bundle-require@5.1.0(esbuild@0.25.2):
-    dependencies:
-      esbuild: 0.25.2
-      load-tsconfig: 0.2.5
 
   c12@3.0.3(magicast@0.3.5):
     dependencies:
@@ -5566,8 +5773,6 @@ snapshots:
 
   commander@14.0.0: {}
 
-  commander@4.1.1: {}
-
   commander@8.3.0: {}
 
   comment-json@4.2.5:
@@ -5593,8 +5798,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       typedarray: 0.0.6
-
-  confbox@0.1.8: {}
 
   confbox@0.2.2: {}
 
@@ -5892,6 +6095,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
+  diff@8.0.2: {}
+
   dir-glob@2.2.2:
     dependencies:
       path-type: 3.0.0
@@ -5924,6 +6129,10 @@ snapshots:
 
   dotenv@16.5.0: {}
 
+  dts-resolver@2.1.1(oxc-resolver@11.2.0):
+    optionalDependencies:
+      oxc-resolver: 11.2.0
+
   eastasianwidth@0.2.0: {}
 
   editorconfig@2.0.1:
@@ -5938,6 +6147,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  empathic@2.0.0: {}
 
   end-of-stream@1.4.4:
     dependencies:
@@ -6330,12 +6541,6 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  fix-dts-default-cjs-exports@1.0.1:
-    dependencies:
-      magic-string: 0.30.17
-      mlly: 1.7.4
-      rollup: 4.39.0
-
   flat-cache@4.0.1:
     dependencies:
       flatted: 3.3.3
@@ -6384,6 +6589,10 @@ snapshots:
       is-stream: 4.0.1
 
   get-tsconfig@4.10.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
@@ -6512,6 +6721,8 @@ snapshots:
       is-obj: 3.0.0
       sort-keys: 5.1.0
       type-fest: 4.37.0
+
+  hookable@5.5.3: {}
 
   hosted-git-info@7.0.2:
     dependencies:
@@ -6749,8 +6960,6 @@ snapshots:
 
   jiti@2.5.0: {}
 
-  joycon@3.1.1: {}
-
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -6859,8 +7068,6 @@ snapshots:
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
 
-  load-tsconfig@0.2.5: {}
-
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
@@ -6876,8 +7083,6 @@ snapshots:
   lodash.isstring@4.0.1: {}
 
   lodash.merge@4.6.2: {}
-
-  lodash.sortby@4.7.0: {}
 
   lodash.uniqby@4.7.0: {}
 
@@ -7196,13 +7401,6 @@ snapshots:
 
   minipass@7.1.2: {}
 
-  mlly@1.7.4:
-    dependencies:
-      acorn: 8.15.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.1
-
   mount-point@3.0.0:
     dependencies:
       '@sindresorhus/df': 1.0.1
@@ -7216,12 +7414,6 @@ snapshots:
   ms@2.1.3: {}
 
   mute-stream@2.0.0: {}
-
-  mz@2.7.0:
-    dependencies:
-      any-promise: 1.3.0
-      object-assign: 4.1.1
-      thenify-all: 1.6.0
 
   nano-spawn@1.0.2: {}
 
@@ -7287,8 +7479,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.1.0
       tinyexec: 0.3.2
-
-  object-assign@4.1.1: {}
 
   object-strings-deep@0.1.2: {}
 
@@ -7546,27 +7736,11 @@ snapshots:
 
   pinkie@2.0.4: {}
 
-  pirates@4.0.6: {}
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.7.4
-      pathe: 2.0.3
-
   pkg-types@2.1.0:
     dependencies:
       confbox: 0.2.2
       exsolve: 1.0.5
       pathe: 2.0.3
-
-  postcss-load-config@6.0.1(jiti@2.5.0)(postcss@8.5.3)(yaml@2.8.0):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      jiti: 2.5.0
-      postcss: 8.5.3
-      yaml: 2.8.0
 
   postcss@8.5.3:
     dependencies:
@@ -7635,6 +7809,8 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  quansync@0.2.10: {}
 
   queue-microtask@1.2.3: {}
 
@@ -7732,6 +7908,45 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rolldown-plugin-dts@0.15.5(oxc-resolver@11.2.0)(rolldown@1.0.0-beta.31)(typescript@5.9.2):
+    dependencies:
+      '@babel/generator': 7.28.0
+      '@babel/parser': 7.28.0
+      '@babel/types': 7.28.2
+      ast-kit: 2.1.1
+      birpc: 2.5.0
+      debug: 4.4.1
+      dts-resolver: 2.1.1(oxc-resolver@11.2.0)
+      get-tsconfig: 4.10.1
+      rolldown: 1.0.0-beta.31
+    optionalDependencies:
+      typescript: 5.9.2
+    transitivePeerDependencies:
+      - oxc-resolver
+      - supports-color
+
+  rolldown@1.0.0-beta.31:
+    dependencies:
+      '@oxc-project/runtime': 0.80.0
+      '@oxc-project/types': 0.80.0
+      '@rolldown/pluginutils': 1.0.0-beta.31
+      ansis: 4.1.0
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-beta.31
+      '@rolldown/binding-darwin-arm64': 1.0.0-beta.31
+      '@rolldown/binding-darwin-x64': 1.0.0-beta.31
+      '@rolldown/binding-freebsd-x64': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-beta.31
+      '@rolldown/binding-linux-arm64-ohos': 1.0.0-beta.31
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-beta.31
+      '@rolldown/binding-linux-x64-musl': 1.0.0-beta.31
+      '@rolldown/binding-wasm32-wasi': 1.0.0-beta.31
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-beta.31
+      '@rolldown/binding-win32-ia32-msvc': 1.0.0-beta.31
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-beta.31
 
   rollup@4.39.0:
     dependencies:
@@ -7886,10 +8101,6 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  source-map@0.8.0-beta.0:
-    dependencies:
-      whatwg-url: 7.1.0
-
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -7959,16 +8170,6 @@ snapshots:
 
   strip-json-comments@5.0.2: {}
 
-  sucrase@3.35.0:
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.8
-      commander: 4.1.1
-      glob: 10.4.5
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.6
-      ts-interface-checker: 0.1.13
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -7989,14 +8190,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       glob: 10.4.5
       minimatch: 9.0.5
-
-  thenify-all@1.6.0:
-    dependencies:
-      thenify: 3.3.1
-
-  thenify@3.3.1:
-    dependencies:
-      any-promise: 1.3.0
 
   throttled-queue@2.1.4: {}
 
@@ -8034,10 +8227,6 @@ snapshots:
 
   toad-cache@3.7.0: {}
 
-  tr46@1.0.1:
-    dependencies:
-      punycode: 2.3.1
-
   trash-cli@6.0.0:
     dependencies:
       meow: 13.2.0
@@ -8064,37 +8253,31 @@ snapshots:
       picomatch: 4.0.2
       typescript: 5.9.2
 
-  ts-interface-checker@0.1.13: {}
-
-  tslib@2.8.1: {}
-
-  tsup@8.5.0(jiti@2.5.0)(postcss@8.5.3)(typescript@5.9.2)(yaml@2.8.0):
+  tsdown@0.13.3(oxc-resolver@11.2.0)(typescript@5.9.2):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.25.2)
+      ansis: 4.1.0
       cac: 6.7.14
       chokidar: 4.0.3
-      consola: 3.4.0
       debug: 4.4.1
-      esbuild: 0.25.2
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.5.0)(postcss@8.5.3)(yaml@2.8.0)
-      resolve-from: 5.0.0
-      rollup: 4.39.0
-      source-map: 0.8.0-beta.0
-      sucrase: 3.35.0
-      tinyexec: 0.3.2
+      diff: 8.0.2
+      empathic: 2.0.0
+      hookable: 5.5.3
+      rolldown: 1.0.0-beta.31
+      rolldown-plugin-dts: 0.15.5(oxc-resolver@11.2.0)(rolldown@1.0.0-beta.31)(typescript@5.9.2)
+      semver: 7.7.2
+      tinyexec: 1.0.1
       tinyglobby: 0.2.14
       tree-kill: 1.2.2
+      unconfig: 7.3.2
     optionalDependencies:
-      postcss: 8.5.3
       typescript: 5.9.2
     transitivePeerDependencies:
-      - jiti
+      - '@typescript/native-preview'
+      - oxc-resolver
       - supports-color
-      - tsx
-      - yaml
+      - vue-tsc
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:
@@ -8123,10 +8306,15 @@ snapshots:
 
   uc.micro@2.1.0: {}
 
-  ufo@1.6.1: {}
-
   uglify-js@3.19.3:
     optional: true
+
+  unconfig@7.3.2:
+    dependencies:
+      '@quansync/fs': 0.1.3
+      defu: 6.1.4
+      jiti: 2.5.0
+      quansync: 0.2.10
 
   undici-types@6.21.0: {}
 
@@ -8242,14 +8430,6 @@ snapshots:
   vscode-uri@3.1.0: {}
 
   walk-up-path@4.0.0: {}
-
-  webidl-conversions@4.0.2: {}
-
-  whatwg-url@7.1.0:
-    dependencies:
-      lodash.sortby: 4.7.0
-      tr46: 1.0.1
-      webidl-conversions: 4.0.2
 
   which@2.0.2:
     dependencies:

--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -3,7 +3,7 @@ import type * as ESTree from "estree";
 import { AST, Rule, SourceCode } from "eslint";
 import { AST as JsonAST, RuleListener } from "jsonc-eslint-parser";
 
-import { isPackageJson } from "./utils/isPackageJson.js";
+import { isPackageJson } from "./utils/isPackageJson.ts";
 
 export type JsonAstBodyExpression = ESTree.Expression & {
 	properties: JsonAstBodyProperty[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { plugin } from "./plugin.js";
+import { plugin } from "./plugin.ts";
 
 export const rules = plugin.rules;
 export const configs = plugin.configs;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -2,23 +2,23 @@ import { Linter } from "eslint";
 import * as parserJsonc from "jsonc-eslint-parser";
 import { createRequire } from "node:module";
 
-import type { PackageJsonRuleModule } from "./createRule.js";
+import type { PackageJsonRuleModule } from "./createRule.ts";
 
-import { rule as noEmptyFields } from "./rules/no-empty-fields.js";
-import { rule as noRedundantFiles } from "./rules/no-redundant-files.js";
-import { rule as orderProperties } from "./rules/order-properties.js";
-import { rule as preferRepositoryShorthand } from "./rules/repository-shorthand.js";
-import { rules as requireRules } from "./rules/require-properties.js";
-import { rule as restrictDependencyRanges } from "./rules/restrict-dependency-ranges.js";
-import { rule as sortCollections } from "./rules/sort-collections.js";
-import { rule as uniqueDependencies } from "./rules/unique-dependencies.js";
-import { rule as validBin } from "./rules/valid-bin.js";
-import { rule as validLocalDependency } from "./rules/valid-local-dependency.js";
-import { rule as validName } from "./rules/valid-name.js";
-import { rule as validPackageDefinition } from "./rules/valid-package-definition.js";
-import { rules as basicValidRules } from "./rules/valid-properties.js";
-import { rule as validRepositoryDirectory } from "./rules/valid-repository-directory.js";
-import { rule as validVersion } from "./rules/valid-version.js";
+import { rule as noEmptyFields } from "./rules/no-empty-fields.ts";
+import { rule as noRedundantFiles } from "./rules/no-redundant-files.ts";
+import { rule as orderProperties } from "./rules/order-properties.ts";
+import { rule as preferRepositoryShorthand } from "./rules/repository-shorthand.ts";
+import { rules as requireRules } from "./rules/require-properties.ts";
+import { rule as restrictDependencyRanges } from "./rules/restrict-dependency-ranges.ts";
+import { rule as sortCollections } from "./rules/sort-collections.ts";
+import { rule as uniqueDependencies } from "./rules/unique-dependencies.ts";
+import { rule as validBin } from "./rules/valid-bin.ts";
+import { rule as validLocalDependency } from "./rules/valid-local-dependency.ts";
+import { rule as validName } from "./rules/valid-name.ts";
+import { rule as validPackageDefinition } from "./rules/valid-package-definition.ts";
+import { rules as basicValidRules } from "./rules/valid-properties.ts";
+import { rule as validRepositoryDirectory } from "./rules/valid-repository-directory.ts";
+import { rule as validVersion } from "./rules/valid-version.ts";
 
 const require = createRequire(import.meta.url);
 

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -6,7 +6,7 @@ import {
 } from "eslint-fix-utils";
 import * as ESTree from "estree";
 
-import { createRule, PackageJsonRuleContext } from "../createRule.js";
+import { createRule, PackageJsonRuleContext } from "../createRule.ts";
 
 interface Option {
 	ignoreProperties?: string[];

--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -3,8 +3,8 @@ import type { AST as JsonAST } from "jsonc-eslint-parser";
 import { fixRemoveArrayElement } from "eslint-fix-utils";
 import * as ESTree from "estree";
 
-import { createRule } from "../createRule.js";
-import { isJSONStringLiteral, isNotNullish } from "../utils/predicates.js";
+import { createRule } from "../createRule.ts";
+import { isJSONStringLiteral, isNotNullish } from "../utils/predicates.ts";
 
 const defaultFiles = [
 	/* cspell:disable-next-line */

--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -5,7 +5,7 @@ import { detectNewlineGraceful } from "detect-newline";
 import sortObjectKeys from "sort-object-keys";
 import { sortOrder } from "sort-package-json";
 
-import { createRule } from "../createRule.js";
+import { createRule } from "../createRule.ts";
 
 const standardOrderLegacy = [
 	"name",

--- a/src/rules/repository-shorthand.ts
+++ b/src/rules/repository-shorthand.ts
@@ -1,8 +1,8 @@
-import { JSONProperty } from "jsonc-eslint-parser/lib/parser/ast.js";
+import { JSONProperty } from "jsonc-eslint-parser/lib/parser/ast.ts";
 
-import { createRule } from "../createRule.js";
-import { findPropertyWithKeyValue } from "../utils/findPropertyWithKeyValue.js";
-import { isJSONStringLiteral } from "../utils/predicates.js";
+import { createRule } from "../createRule.ts";
+import { findPropertyWithKeyValue } from "../utils/findPropertyWithKeyValue.ts";
+import { isJSONStringLiteral } from "../utils/predicates.ts";
 
 const githubUrlRegex =
 	/^(?:git\+)?(?:ssh:\/\/git@|http?s:\/\/)?(?:www\.)?github\.com\//;

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -2,8 +2,8 @@ import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import semver from "semver";
 
-import { createRule } from "../createRule.js";
-import { isJSONStringLiteral } from "../utils/predicates.js";
+import { createRule } from "../createRule.ts";
+import { isJSONStringLiteral } from "../utils/predicates.ts";
 
 const DEPENDENCY_TYPES = [
 	"dependencies",

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -2,7 +2,7 @@ import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import sortPackageJson from "sort-package-json";
 
-import { createRule } from "../createRule.js";
+import { createRule } from "../createRule.ts";
 
 const defaultCollections = new Set([
 	"config",

--- a/src/rules/unique-dependencies.ts
+++ b/src/rules/unique-dependencies.ts
@@ -6,8 +6,8 @@ import {
 } from "eslint-fix-utils";
 import * as ESTree from "estree";
 
-import { createRule } from "../createRule.js";
-import { isJSONStringLiteral, isNotNullish } from "../utils/predicates.js";
+import { createRule } from "../createRule.ts";
+import { isJSONStringLiteral, isNotNullish } from "../utils/predicates.ts";
 
 const dependencyPropertyNames = new Set([
 	"bundledDependencies",

--- a/src/rules/valid-bin.ts
+++ b/src/rules/valid-bin.ts
@@ -2,8 +2,8 @@ import { kebabCase } from "change-case";
 import { AST as JsonAST } from "jsonc-eslint-parser";
 import { validateBin } from "package-json-validator";
 
-import { createRule } from "../createRule.js";
-import { formatErrors } from "../utils/formatErrors.js";
+import { createRule } from "../createRule.ts";
+import { formatErrors } from "../utils/formatErrors.ts";
 
 type Options = [{ enforceCase: boolean }?];
 

--- a/src/rules/valid-local-dependency.ts
+++ b/src/rules/valid-local-dependency.ts
@@ -1,6 +1,6 @@
 import path from "path";
 
-import { createRule } from "../createRule.js";
+import { createRule } from "../createRule.ts";
 
 const fileRegex = /^file:/;
 const linkRegex = /^link:/;

--- a/src/rules/valid-local-dependency.ts
+++ b/src/rules/valid-local-dependency.ts
@@ -1,6 +1,9 @@
-import path from "path";
+import { createRequire } from "node:module";
+import path from "node:path";
 
 import { createRule } from "../createRule.ts";
+
+const require = createRequire(import.meta.url);
 
 const fileRegex = /^file:/;
 const linkRegex = /^link:/;

--- a/src/rules/valid-name.ts
+++ b/src/rules/valid-name.ts
@@ -2,7 +2,7 @@ import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import validate from "validate-npm-package-name";
 
-import { createRule } from "../createRule.js";
+import { createRule } from "../createRule.ts";
 
 export const rule = createRule({
 	create(context) {

--- a/src/rules/valid-package-definition.ts
+++ b/src/rules/valid-package-definition.ts
@@ -1,6 +1,6 @@
 import { validate } from "package-json-validator";
 
-import { createRule } from "../createRule.js";
+import { createRule } from "../createRule.ts";
 
 interface Option {
 	ignoreProperties?: string[];

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -10,7 +10,7 @@ import {
 	validateType,
 } from "package-json-validator";
 
-import type { PackageJsonRuleModule } from "../createRule.js";
+import type { PackageJsonRuleModule } from "../createRule.ts";
 
 import {
 	createSimpleValidPropertyRule,

--- a/src/rules/valid-repository-directory.ts
+++ b/src/rules/valid-repository-directory.ts
@@ -4,8 +4,8 @@ import { findRootSync } from "@altano/repository-tools";
 import * as path from "node:path";
 import { sep as posixSep } from "node:path/posix";
 
-import { createRule } from "../createRule.js";
-import { findPropertyWithKeyValue } from "../utils/findPropertyWithKeyValue.js";
+import { createRule } from "../createRule.ts";
+import { findPropertyWithKeyValue } from "../utils/findPropertyWithKeyValue.ts";
 
 /**
  * Checks if the child path appears at the end of the parent path.

--- a/src/rules/valid-version.ts
+++ b/src/rules/valid-version.ts
@@ -2,7 +2,7 @@ import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import semver from "semver";
 
-import { createRule } from "../createRule.js";
+import { createRule } from "../createRule.ts";
 
 export const rule = createRule({
 	create(context) {

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
-import plugin from "../index.js";
+import plugin from "../index.ts";
 
 describe("configs", () => {
 	it("configs should work properly", async () => {

--- a/src/tests/rules/no-empty-fields.test.ts
+++ b/src/tests/rules/no-empty-fields.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/no-empty-fields.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/no-empty-fields.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("no-empty-fields", rule, {
 	invalid: [

--- a/src/tests/rules/no-redundant-files.test.ts
+++ b/src/tests/rules/no-redundant-files.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/no-redundant-files.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/no-redundant-files.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("no-redundant-files", rule, {
 	invalid: [
@@ -407,7 +407,7 @@ ruleTester.run("no-redundant-files", rule, {
 	}`,
 
 		`{
-		"main": "./index.js", 
+		"main": "./index.js",
 		"files": [
 			"*.d.ts",
 			"dist/specific-file.js",

--- a/src/tests/rules/order-properties.test.ts
+++ b/src/tests/rules/order-properties.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/order-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/order-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("order-properties", rule, {
 	invalid: [

--- a/src/tests/rules/repository-shorthand.test.ts
+++ b/src/tests/rules/repository-shorthand.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/repository-shorthand.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/repository-shorthand.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("repository-shorthand", rule, {
 	invalid: [

--- a/src/tests/rules/require-properties.test.ts
+++ b/src/tests/rules/require-properties.test.ts
@@ -1,7 +1,7 @@
-import type { PackageJsonPluginSettings } from "../../createRule.js";
+import type { PackageJsonPluginSettings } from "../../createRule.ts";
 
-import { rules } from "../../rules/require-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/require-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 const ruleNames = Object.keys(rules);
 

--- a/src/tests/rules/restrict-dependency-ranges.test.ts
+++ b/src/tests/rules/restrict-dependency-ranges.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/restrict-dependency-ranges.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/restrict-dependency-ranges.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("restrict-dependency-ranges", rule, {
 	invalid: [

--- a/src/tests/rules/ruleTester.ts
+++ b/src/tests/rules/ruleTester.ts
@@ -2,7 +2,7 @@ import { RuleTester } from "eslint";
 import jsoncESLintParser from "jsonc-eslint-parser";
 import * as vitest from "vitest";
 
-import type { PackageJsonRuleModule } from "../../createRule.js";
+import type { PackageJsonRuleModule } from "../../createRule.ts";
 
 export type JsonRuleTester = RuleTester & {
 	run: JsonRuleTesterRun;

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/sort-collections.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/sort-collections.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 //------------------------------------------------------------------------------
 // Tests

--- a/src/tests/rules/unique-dependencies.test.ts
+++ b/src/tests/rules/unique-dependencies.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/unique-dependencies.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/unique-dependencies.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("unique-dependencies", rule, {
 	invalid: [
@@ -9,8 +9,6 @@ ruleTester.run("unique-dependencies", rule, {
 	}`,
 			errors: [
 				{
-					column: 26,
-					endColumn: 31,
 					line: 2,
 					messageId: "overridden",
 					suggestions: [
@@ -31,8 +29,6 @@ ruleTester.run("unique-dependencies", rule, {
 	}`,
 			errors: [
 				{
-					column: 27,
-					endColumn: 32,
 					line: 2,
 					messageId: "overridden",
 					suggestions: [
@@ -50,26 +46,24 @@ ruleTester.run("unique-dependencies", rule, {
 		// ...
 		{
 			code: `{
-		"dependencies": {
-			"abc": "1.2.3",
-			"abc": "1.2.3"
-		}
-	}`,
+	"dependencies": {
+		"abc": "1.2.3",
+		"abc": "1.2.3"
+	}
+}`,
 			errors: [
 				{
-					column: 4,
-					endColumn: 9,
 					line: 3,
 					messageId: "overridden",
 					suggestions: [
 						{
 							messageId: "remove",
 							output: `{
-		"dependencies": {
-			
-			"abc": "1.2.3"
-		}
-	}`,
+	"dependencies": {
+\t\t
+		"abc": "1.2.3"
+	}
+}`,
 						},
 					],
 				},
@@ -79,26 +73,24 @@ ruleTester.run("unique-dependencies", rule, {
 		// ...
 		{
 			code: `{
-		"devDependencies": {
-			"abc": "1.2.3",
-			"abc": "1.2.3"
-		}
-	}`,
+	"devDependencies": {
+		"abc": "1.2.3",
+		"abc": "1.2.3"
+	}
+}`,
 			errors: [
 				{
-					column: 4,
-					endColumn: 9,
 					line: 3,
 					messageId: "overridden",
 					suggestions: [
 						{
 							messageId: "remove",
 							output: `{
-		"devDependencies": {
-			
-			"abc": "1.2.3"
-		}
-	}`,
+	"devDependencies": {
+\t\t
+		"abc": "1.2.3"
+	}
+}`,
 						},
 					],
 				},
@@ -107,26 +99,24 @@ ruleTester.run("unique-dependencies", rule, {
 		},
 		{
 			code: `{
-		"optionalDependencies": {
-			"abc": "1.2.3",
-			"abc": "1.2.3"
-		}
-	}`,
+	"optionalDependencies": {
+		"abc": "1.2.3",
+		"abc": "1.2.3"
+	}
+}`,
 			errors: [
 				{
-					column: 4,
-					endColumn: 9,
 					line: 3,
 					messageId: "overridden",
 					suggestions: [
 						{
 							messageId: "remove",
 							output: `{
-		"optionalDependencies": {
-			
-			"abc": "1.2.3"
-		}
-	}`,
+	"optionalDependencies": {
+\t\t
+		"abc": "1.2.3"
+	}
+}`,
 						},
 					],
 				},
@@ -135,26 +125,24 @@ ruleTester.run("unique-dependencies", rule, {
 		},
 		{
 			code: `{
-		"peerDependencies": {
-			"abc": "1.2.3",
-			"abc": "1.2.3"
-		}
-	}`,
+	"peerDependencies": {
+		"abc": "1.2.3",
+		"abc": "1.2.3"
+	}
+}`,
 			errors: [
 				{
-					column: 4,
-					endColumn: 9,
 					line: 3,
 					messageId: "overridden",
 					suggestions: [
 						{
 							messageId: "remove",
 							output: `{
-		"peerDependencies": {
-			
-			"abc": "1.2.3"
-		}
-	}`,
+	"peerDependencies": {
+\t\t
+		"abc": "1.2.3"
+	}
+}`,
 						},
 					],
 				},
@@ -169,8 +157,6 @@ ruleTester.run("unique-dependencies", rule, {
 	}`,
 			errors: [
 				{
-					column: 17,
-					endColumn: 22,
 					line: 2,
 					messageId: "overridden",
 					suggestions: [

--- a/src/tests/rules/valid-author.test.ts
+++ b/src/tests/rules/valid-author.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-author", rules["valid-author"], {
 	invalid: [

--- a/src/tests/rules/valid-bin.test.ts
+++ b/src/tests/rules/valid-bin.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/valid-bin.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/valid-bin.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-bin", rule, {
 	invalid: [

--- a/src/tests/rules/valid-bundleDependencies.test.ts
+++ b/src/tests/rules/valid-bundleDependencies.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-bundleDependencies", rules["valid-bundleDependencies"], {
 	invalid: ["bundleDependencies", "bundledDependencies"]

--- a/src/tests/rules/valid-config.test.ts
+++ b/src/tests/rules/valid-config.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-config", rules["valid-config"], {
 	invalid: [

--- a/src/tests/rules/valid-cpu.test.ts
+++ b/src/tests/rules/valid-cpu.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-cpu", rules["valid-cpu"], {
 	invalid: [

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-dependencies", rules["valid-dependencies"], {
 	invalid: [

--- a/src/tests/rules/valid-description.test.ts
+++ b/src/tests/rules/valid-description.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-description", rules["valid-description"], {
 	invalid: [

--- a/src/tests/rules/valid-devDependencies.test.ts
+++ b/src/tests/rules/valid-devDependencies.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-devDependencies", rules["valid-devDependencies"], {
 	invalid: [

--- a/src/tests/rules/valid-license.test.ts
+++ b/src/tests/rules/valid-license.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-license", rules["valid-license"], {
 	invalid: [

--- a/src/tests/rules/valid-local-dependency.test.ts
+++ b/src/tests/rules/valid-local-dependency.test.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
-import { rule } from "../../rules/valid-local-dependency.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/valid-local-dependency.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 const fileName = (partialPath: string) => {
 	return path.join(process.cwd(), partialPath);

--- a/src/tests/rules/valid-name.test.ts
+++ b/src/tests/rules/valid-name.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/valid-name.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/valid-name.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-name", rule, {
 	invalid: [

--- a/src/tests/rules/valid-optionalDependencies.test.ts
+++ b/src/tests/rules/valid-optionalDependencies.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run(
 	"valid-optionalDependencies",

--- a/src/tests/rules/valid-package-definition.test.ts
+++ b/src/tests/rules/valid-package-definition.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/valid-package-definition.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/valid-package-definition.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-package-definition", rule, {
 	invalid: [

--- a/src/tests/rules/valid-peerDependencies.test.ts
+++ b/src/tests/rules/valid-peerDependencies.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-peerDependencies", rules["valid-peerDependencies"], {
 	invalid: [

--- a/src/tests/rules/valid-repository-directory.test.ts
+++ b/src/tests/rules/valid-repository-directory.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 
-import { rule } from "../../rules/valid-repository-directory.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/valid-repository-directory.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-repository-directory (no repository)", rule, {
 	invalid: [

--- a/src/tests/rules/valid-scripts.test.ts
+++ b/src/tests/rules/valid-scripts.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-scripts", rules["valid-scripts"], {
 	invalid: [

--- a/src/tests/rules/valid-type.test.ts
+++ b/src/tests/rules/valid-type.test.ts
@@ -1,5 +1,5 @@
-import { rules } from "../../rules/valid-properties.js";
-import { ruleTester } from "./ruleTester.js";
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-type", rules["valid-type"], {
 	invalid: [

--- a/src/tests/rules/valid-version.test.ts
+++ b/src/tests/rules/valid-version.test.ts
@@ -1,5 +1,5 @@
-import { rule } from "../../rules/valid-version.js";
-import { ruleTester } from "./ruleTester.js";
+import { rule } from "../../rules/valid-version.ts";
+import { ruleTester } from "./ruleTester.ts";
 
 ruleTester.run("valid-version", rule, {
 	invalid: [

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -1,7 +1,7 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
-import { createRule } from "../createRule.js";
-import { isJSONStringLiteral } from "./predicates.js";
+import { createRule } from "../createRule.ts";
+import { isJSONStringLiteral } from "./predicates.ts";
 
 export interface CreateRequirePropertyRuleOptions {
 	/**

--- a/src/utils/createSimpleValidPropertyRule.ts
+++ b/src/utils/createSimpleValidPropertyRule.ts
@@ -1,7 +1,7 @@
 import type { AST as JsonAST } from "jsonc-eslint-parser";
 
-import { createRule } from "../createRule.js";
-import { formatErrors } from "./formatErrors.js";
+import { createRule } from "../createRule.ts";
+import { formatErrors } from "./formatErrors.ts";
 
 export type ValidationFunction = (value: unknown) => string[];
 

--- a/src/utils/formatErrors.test.ts
+++ b/src/utils/formatErrors.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { formatErrors } from "./formatErrors.js";
+import { formatErrors } from "./formatErrors.ts";
 
 describe("formatErrors", () => {
 	it("should return the single error string as-is when only one error is present", () => {

--- a/src/utils/isPackageJson.test.ts
+++ b/src/utils/isPackageJson.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { isPackageJson } from "./isPackageJson.js";
+import { isPackageJson } from "./isPackageJson.ts";
 
 describe("isPackageJson", () => {
 	test.each([

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"strict": true,
-		"target": "ES2021"
+		"target": "ES2024",
+		"rewriteRelativeImportExtensions": true
 	},
 	"include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"compilerOptions": {
 		"declaration": true,
-		"declarationMap": true,
 		"esModuleInterop": true,
 		"module": "nodenext",
 		"moduleResolution": "nodenext",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,10 +1,10 @@
-import { defineConfig } from "tsup";
+import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	bundle: false,
 	clean: true,
 	dts: true,
 	entry: ["src/**/*.ts", "!src/**/*.test.*"],
 	format: ["esm"],
 	outDir: "lib",
+	unbundle: true,
 });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,10 +1,8 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-	clean: true,
 	dts: true,
-	entry: ["src/**/*.ts", "!src/**/*.test.*"],
-	format: ["esm"],
+	entry: ["src/**/*.ts", "!src/**/*.test.ts", "!src/tests/**/*"],
 	outDir: "lib",
 	unbundle: true,
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1205 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
This change moves all of our relative path imports to use `.ts` extensions instead of `.js`.  In order to do this, and avoid a bug in `tsup`, we're moving to use `tsdown` for bundling.  There should be no user-facing changes from this update.

This simply sets us up to use node's native type stripping for our own linting within the repo.

I also changed the ci workflow to default node version to the latest lts version.  This doesn't affect the matrix used for the test job.
