### PR TITLE
fix(plugin): update types to be compatible with `defineConfig`

### DIFF
--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -1,7 +1,7 @@
 import type * as ESTree from "estree";
 
 import { AST, Rule, SourceCode } from "eslint";
-import { AST as JsonAST, RuleListener } from "jsonc-eslint-parser";
+import { AST as JsonAST } from "jsonc-eslint-parser";
 
 import { isPackageJson } from "./utils/isPackageJson.ts";
 
@@ -41,7 +41,7 @@ export interface PackageJsonRuleContext<Options extends unknown[] = unknown[]>
 }
 
 export interface PackageJsonRuleModule<Options extends unknown[] = unknown[]> {
-	create(context: PackageJsonRuleContext<Options>): RuleListener;
+	create(context: PackageJsonRuleContext<Options>): Rule.NodeListener;
 	meta: Rule.RuleMetaData;
 }
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { Linter } from "eslint";
+import { type ESLint, type Linter } from "eslint";
 import * as parserJsonc from "jsonc-eslint-parser";
 import { createRequire } from "node:module";
 
@@ -87,7 +87,7 @@ export const plugin = {
 			},
 			name: "package-json/recommended",
 			plugins: {
-				get "package-json"() {
+				get "package-json"(): ESLint.Plugin {
 					return plugin;
 				},
 			},
@@ -99,4 +99,4 @@ export const plugin = {
 		version,
 	},
 	rules,
-};
+} satisfies ESLint.Plugin;

--- a/src/rules/repository-shorthand.ts
+++ b/src/rules/repository-shorthand.ts
@@ -1,4 +1,4 @@
-import { JSONProperty } from "jsonc-eslint-parser/lib/parser/ast.ts";
+import type { AST as JsonAST } from "jsonc-eslint-parser";
 
 import { createRule } from "../createRule.ts";
 import { findPropertyWithKeyValue } from "../utils/findPropertyWithKeyValue.ts";
@@ -20,7 +20,7 @@ export const rule = createRule<Options>({
 	create(context) {
 		const [{ form = "object" } = {}] = context.options;
 
-		function validateRepositoryForObject(node: JSONProperty) {
+		function validateRepositoryForObject(node: JsonAST.JSONProperty) {
 			if (isJSONStringLiteral(node.value)) {
 				context.report({
 					fix(fixer) {
@@ -50,7 +50,7 @@ export const rule = createRule<Options>({
 			}
 		}
 
-		function validateRepositoryForShorthand(node: JSONProperty) {
+		function validateRepositoryForShorthand(node: JsonAST.JSONProperty) {
 			if (isJSONStringLiteral(node.value)) {
 				const { value } = node.value;
 				if (typeof value === "string" && isGitHubUrl(value)) {
@@ -111,7 +111,7 @@ export const rule = createRule<Options>({
 		}
 
 		return {
-			JSONProperty(node) {
+			JSONProperty(node: JsonAST.JSONProperty) {
 				if (
 					node.key.type !== "JSONLiteral" ||
 					node.key.value !== "repository" ||

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -25,7 +25,7 @@ export const rule = createRule<Options>({
 			: defaultCollections;
 
 		return {
-			"JSONProperty:exit"(node) {
+			"JSONProperty:exit"(node: JsonAST.JSONProperty) {
 				const { key: nodeKey, value: collection } = node;
 
 				if (


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1242 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates our plugin types to use `NodeListener` for the return type of `create` instead of jsonc-eslint-parser's `RuleListener` type, which made the plugin incompatible when used with ESLint's `defineConfig` in TypeScript land.
