### PR TITLE
ci: remove lint packages check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,6 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
       - uses: ./.github/actions/prepare
       - run: pnpm lint:md
-  lint_packages:
-    name: Lint Packages
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - uses: ./.github/actions/prepare
-      - run: pnpm lint:packages
   prettier:
     name: Prettier
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
 		"lint:docs": "eslint-doc-generator --check",
 		"lint:knip": "knip",
 		"lint:md": "markdownlint \"**/*.md\" \".github/**/*.md\" --rules sentences-per-line",
-		"lint:packages": "pnpm dedupe --check",
 		"prepare": "husky",
 		"test": "vitest",
 		"typecheck": "tsc"


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The lint packages step is not particularly helpful, and will simply fail PR builds if a renovate pr hasn't landed recently.  dedupe simply installs new versions of transitive deps if they're available, and our CI step fails PR builds if the PR lockfile doesn't always have the latest versions of everything.  I don't think that's really what we want.
