### PR TITLE
fix: re-adopt jsonc-eslint-parser's RuleListener type

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -111,7 +111,7 @@ export default defineConfig(
 		},
 	},
 	{
-		files: ["./eslint.config.mjs", "./**/*.test.*"],
+		files: ["./eslint.config.ts", "./**/*.test.*"],
 		rules: {
 			"n/no-unsupported-features/node-builtins": "off",
 		},

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"husky": "9.1.7",
 		"jiti": "2.6.0",
 		"json-schema-to-ts": "3.1.1",
-		"jsonc-eslint-parser": "2.4.0",
+		"jsonc-eslint-parser": "2.4.1",
 		"knip": "5.64.0",
 		"lint-staged": "16.2.0",
 		"markdownlint": "0.38.0",
@@ -100,7 +100,7 @@
 	},
 	"packageManager": "pnpm@10.18.0",
 	"engines": {
-		"node": "^=20.19.0 || >=22.12.0"
+		"node": "^20.19.0 || >=22.12.0"
 	},
 	"publishConfig": {
 		"provenance": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,8 +109,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1
       jsonc-eslint-parser:
-        specifier: 2.4.0
-        version: 2.4.0
+        specifier: 2.4.1
+        version: 2.4.1
       knip:
         specifier: 5.64.0
         version: 5.64.0(@types/node@22.18.0)(typescript@5.9.2)
@@ -2190,8 +2190,8 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
-  jsonc-eslint-parser@2.4.0:
-    resolution: {integrity: sha512-WYDyuc/uFcGp6YtM2H0uKmUwieOuzeE/5YocFJLnLfclZ4inf3mRn8ZVy1s7Hxji7Jxm6Ss8gqpexD/GlKoGgg==}
+  jsonc-eslint-parser@2.4.1:
+    resolution: {integrity: sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   jsonc-parser@3.3.1:
@@ -4656,11 +4656,11 @@ snapshots:
     optionalDependencies:
       '@types/estree': 1.0.7
 
-  eslint-json-compat-utils@0.2.1(eslint@9.37.0(jiti@2.6.0))(jsonc-eslint-parser@2.4.0):
+  eslint-json-compat-utils@0.2.1(eslint@9.37.0(jiti@2.6.0))(jsonc-eslint-parser@2.4.1):
     dependencies:
       eslint: 9.37.0(jiti@2.6.0)
       esquery: 1.6.0
-      jsonc-eslint-parser: 2.4.0
+      jsonc-eslint-parser: 2.4.1
 
   eslint-plugin-es-x@7.8.0(eslint@9.37.0(jiti@2.6.0)):
     dependencies:
@@ -4699,10 +4699,10 @@ snapshots:
       diff-sequences: 27.5.1
       eslint: 9.37.0(jiti@2.6.0)
       eslint-compat-utils: 0.6.4(eslint@9.37.0(jiti@2.6.0))
-      eslint-json-compat-utils: 0.2.1(eslint@9.37.0(jiti@2.6.0))(jsonc-eslint-parser@2.4.0)
+      eslint-json-compat-utils: 0.2.1(eslint@9.37.0(jiti@2.6.0))(jsonc-eslint-parser@2.4.1)
       espree: 10.4.0
       graphemer: 1.4.0
-      jsonc-eslint-parser: 2.4.0
+      jsonc-eslint-parser: 2.4.1
       natural-compare: 1.4.0
       synckit: 0.6.2
     transitivePeerDependencies:
@@ -5236,7 +5236,7 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
-  jsonc-eslint-parser@2.4.0:
+  jsonc-eslint-parser@2.4.1:
     dependencies:
       acorn: 8.15.0
       eslint-visitor-keys: 3.4.3

--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -5,7 +5,7 @@ import type {
 } from "json-schema-to-ts";
 
 import { AST, Rule, SourceCode } from "eslint";
-import { AST as JsonAST } from "jsonc-eslint-parser";
+import { AST as JsonAST, type RuleListener } from "jsonc-eslint-parser";
 
 import { isPackageJson } from "./utils/isPackageJson.ts";
 
@@ -48,7 +48,7 @@ export interface PackageJsonRuleModule<
 	Options extends unknown[] = unknown[],
 	Schema extends JSONSchema[] = JSONSchema[],
 > {
-	create(context: PackageJsonRuleContext<Options>): Rule.NodeListener;
+	create(context: PackageJsonRuleContext<Options>): RuleListener;
 	meta: Omit<Rule.RuleMetaData, "defaultOptions" | "schema"> & {
 		defaultOptions?: NoInfer<Options>;
 		schema?: Schema;

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -99,7 +99,7 @@ export const rule = createRule({
 		const ignoreProperties = context.options[0]?.ignoreProperties ?? [];
 
 		return {
-			JSONArrayExpression(node: JsonAST.JSONArrayExpression) {
+			JSONArrayExpression(node) {
 				const topLevelProperty = getTopLevelProperty(node);
 				// If this is the root object, we shouldn't proceed
 				if (!topLevelProperty) {
@@ -112,7 +112,7 @@ export const rule = createRule({
 					}
 				}
 			},
-			JSONObjectExpression(node: JsonAST.JSONObjectExpression) {
+			JSONObjectExpression(node) {
 				const topLevelProperty = getTopLevelProperty(node);
 				// If this is the root object, we shouldn't proceed
 				if (!topLevelProperty) {

--- a/src/rules/repository-shorthand.ts
+++ b/src/rules/repository-shorthand.ts
@@ -107,7 +107,7 @@ export const rule = createRule({
 		}
 
 		return {
-			JSONProperty(node: JsonAST.JSONProperty) {
+			JSONProperty(node) {
 				if (
 					node.key.type !== "JSONLiteral" ||
 					node.key.value !== "repository" ||

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -23,7 +23,7 @@ export const rule = createRule({
 			: defaultCollections;
 
 		return {
-			"JSONProperty:exit"(node: JsonAST.JSONProperty) {
+			"JSONProperty:exit"(node) {
 				const { key: nodeKey, value: collection } = node;
 
 				if (


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change undoes the change introduced in https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/pull/1245, following the merge of the upstream bugfix: https://github.com/ota-meshi/jsonc-eslint-parser/pull/228
