### PR TITLE
fix(valid-bin, valid-bundleDependencies): improve report precision

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"detect-indent": "^7.0.2",
 		"detect-newline": "^4.0.1",
 		"eslint-fix-utils": "~0.4.0",
-		"package-json-validator": "~0.33.0",
+		"package-json-validator": "~0.34.0",
 		"semver": "^7.7.3",
 		"sort-object-keys": "^2.0.0",
 		"sort-package-json": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ~0.4.0
         version: 0.4.0(@types/estree@1.0.7)(eslint@9.38.0(jiti@2.6.0))
       package-json-validator:
-        specifier: ~0.33.0
-        version: 0.33.0
+        specifier: ~0.34.0
+        version: 0.34.0
       semver:
         specifier: ^7.7.3
         version: 7.7.3
@@ -2513,8 +2513,8 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  package-json-validator@0.33.0:
-    resolution: {integrity: sha512-mtWbp27J9fOd3DF9XtVfBw2fbqL89wnHf3aFkKIa7Z5qLUsUT5M0/qhyelXJv+FtMJ4/Vxfp3pssbbjPVeOXUA==}
+  package-json-validator@0.34.0:
+    resolution: {integrity: sha512-kij4ALmQrfqNBPgfgTs3c6mbGwpG0M3Di8dtkt9RFXg73cFKxberr7SW0kwMHgJ8PNVq+QnOP12p7TFzMxgJZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -5635,7 +5635,7 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  package-json-validator@0.33.0:
+  package-json-validator@0.34.0:
     dependencies:
       semver: 7.7.3
       validate-npm-package-license: 3.0.4

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -20,21 +20,9 @@ import {
 	type ValidationFunction,
 } from "../utils/createSimpleValidPropertyRule.js";
 
-interface LegacyValidPropertyOptions {
-	aliases: string[];
-	validator: LegacyValidationFunction;
-}
-
 // List of all properties we want to create valid- rules for,
 // in the format [propertyName, legacyValidationFunction | validPropertyOptions]
 const legacyProperties = [
-	[
-		"bundleDependencies",
-		{
-			aliases: ["bundledDependencies"],
-			validator: validateBundleDependencies,
-		},
-	],
 	["config", validateConfig],
 	["cpu", validateCpu],
 	["dependencies", validateDependencies],
@@ -47,22 +35,13 @@ const legacyProperties = [
 	["peerDependencies", validateDependencies],
 	["scripts", validateScripts],
 	["type", validateType],
-] satisfies [string, LegacyValidationFunction | LegacyValidPropertyOptions][];
+] satisfies [string, LegacyValidationFunction][];
 
 const legacyRules = Object.fromEntries(
-	legacyProperties.map(([propertyName, validationFunctionOrOptions]) => {
-		let validationFunction: LegacyValidationFunction;
-		let aliases: string[] = [];
-		if (typeof validationFunctionOrOptions === "object") {
-			validationFunction = validationFunctionOrOptions.validator;
-			aliases = validationFunctionOrOptions.aliases;
-		} else {
-			validationFunction = validationFunctionOrOptions;
-		}
+	legacyProperties.map(([propertyName, validationFunction]) => {
 		const { rule, ruleName } = createLegacySimpleValidPropertyRule(
 			propertyName,
 			validationFunction,
-			aliases,
 		);
 		return [ruleName, rule];
 	}),
@@ -78,6 +57,13 @@ interface ValidPropertyOptions {
 const properties = [
 	["author", validateAuthor],
 	["bin", validateBin],
+	[
+		"bundleDependencies",
+		{
+			aliases: ["bundledDependencies"],
+			validator: validateBundleDependencies,
+		},
+	],
 	// TODO: More to come!
 ] satisfies [string, ValidationFunction | ValidPropertyOptions][];
 
@@ -86,8 +72,14 @@ export const rules = {
 	...legacyRules,
 	...Object.fromEntries(
 		properties.map(([propertyName, validationFunctionOrOptions]) => {
-			const validationFunction = validationFunctionOrOptions;
-			const aliases: string[] = [];
+			let validationFunction: ValidationFunction;
+			let aliases: string[] = [];
+			if (typeof validationFunctionOrOptions === "object") {
+				validationFunction = validationFunctionOrOptions.validator;
+				aliases = validationFunctionOrOptions.aliases;
+			} else {
+				validationFunction = validationFunctionOrOptions;
+			}
 			const { rule, ruleName } = createSimpleValidPropertyRule(
 				propertyName,
 				validationFunction,

--- a/src/tests/rules/valid-bin.test.ts
+++ b/src/tests/rules/valid-bin.test.ts
@@ -11,7 +11,7 @@ ruleTester.run("valid-bin", rules["valid-bin"], {
 			errors: [
 				{
 					data: {
-						error: "field is `null`, but should be a `string` or an `object`",
+						error: "the value is `null`, but should be a `string` or an `object`",
 					},
 					line: 2,
 					messageId: "validationError",
@@ -26,7 +26,7 @@ ruleTester.run("valid-bin", rules["valid-bin"], {
 			errors: [
 				{
 					data: {
-						error: "type should be `string` or `object`, not `number`",
+						error: "the type should be `string` or `object`, not `number`",
 					},
 					line: 2,
 					messageId: "validationError",
@@ -41,7 +41,7 @@ ruleTester.run("valid-bin", rules["valid-bin"], {
 			errors: [
 				{
 					data: {
-						error: "field is empty, but should be a relative path",
+						error: "the value is empty, but should be a relative path",
 					},
 					line: 2,
 					messageId: "validationError",
@@ -58,7 +58,7 @@ ruleTester.run("valid-bin", rules["valid-bin"], {
 			errors: [
 				{
 					data: {
-						error: 'bin field "invalid-bin" should be a string',
+						error: 'the value of property "invalid-bin" should be a string',
 					},
 					line: 3,
 					messageId: "validationError",
@@ -75,7 +75,7 @@ ruleTester.run("valid-bin", rules["valid-bin"], {
 			errors: [
 				{
 					data: {
-						error: 'bin field "invalid-bin" is empty, but should be a relative path',
+						error: 'the value of property "invalid-bin" is empty, but should be a relative path',
 					},
 					line: 3,
 					messageId: "validationError",
@@ -92,7 +92,7 @@ ruleTester.run("valid-bin", rules["valid-bin"], {
 			errors: [
 				{
 					data: {
-						error: "bin field 0 has an empty key, but should be a valid command name",
+						error: "property 0 has an empty key, but should be a valid command name",
 					},
 					line: 3,
 					messageId: "validationError",
@@ -110,14 +110,14 @@ ruleTester.run("valid-bin", rules["valid-bin"], {
 			errors: [
 				{
 					data: {
-						error: "bin field 0 has an empty key, but should be a valid command name",
+						error: "property 0 has an empty key, but should be a valid command name",
 					},
 					line: 3,
 					messageId: "validationError",
 				},
 				{
 					data: {
-						error: "bin field 1 has an empty key, but should be a valid command name",
+						error: "property 1 has an empty key, but should be a valid command name",
 					},
 					line: 4,
 					messageId: "validationError",

--- a/src/tests/rules/valid-bundleDependencies.test.ts
+++ b/src/tests/rules/valid-bundleDependencies.test.ts
@@ -12,9 +12,9 @@ ruleTester.run("valid-bundleDependencies", rules["valid-bundleDependencies"], {
 				errors: [
 					{
 						data: {
-							errors: "the field is `null`, but should be an `Array` or a `boolean`",
-							property,
+							error: "the value is `null`, but should be an `Array` or a `boolean`",
 						},
+						line: 2,
 						messageId: "validationError",
 					},
 				],
@@ -27,9 +27,9 @@ ruleTester.run("valid-bundleDependencies", rules["valid-bundleDependencies"], {
 				errors: [
 					{
 						data: {
-							errors: "the type should be `Array` or `boolean`, not `number`",
-							property,
+							error: "the type should be `Array` or `boolean`, not `number`",
 						},
+						line: 2,
 						messageId: "validationError",
 					},
 				],
@@ -42,42 +42,60 @@ ruleTester.run("valid-bundleDependencies", rules["valid-bundleDependencies"], {
 				errors: [
 					{
 						data: {
-							errors: "the type should be `Array` or `boolean`, not `string`",
-							property,
+							error: "the type should be `Array` or `boolean`, not `string`",
 						},
+						line: 2,
 						messageId: "validationError",
 					},
 				],
 			},
 			{
 				code: `{
-	"${property}": { "invalid-bin": 123 }
+	"${property}": {
+      "invalid-bin": 123
+    }
 }
 `,
 				errors: [
 					{
 						data: {
-							errors: "the type should be `Array` or `boolean`, not `object`",
-							property,
+							error: "the type should be `Array` or `boolean`, not `object`",
 						},
+						line: 2,
 						messageId: "validationError",
 					},
 				],
 			},
 			{
 				code: `{
-	"${property}": ["valid", "", 123, null]
+	"${property}": [
+      "valid",
+      "",
+      123,
+      null
+    ]
 }
 `,
 				errors: [
 					{
 						data: {
-							errors: `
- - item at index 1 is empty, but should be a dependency name
- - item at index 2 should be a string, not \`number\`
- - item at index 3 should be a string, not \`null\``,
-							property,
+							error: "item at index 1 is empty, but should be a dependency name",
 						},
+						line: 4,
+						messageId: "validationError",
+					},
+					{
+						data: {
+							error: "item at index 2 should be a string, not `number`",
+						},
+						line: 5,
+						messageId: "validationError",
+					},
+					{
+						data: {
+							error: "item at index 3 should be a string, not `null`",
+						},
+						line: 6,
 						messageId: "validationError",
 					},
 				],

--- a/src/utils/createSimpleValidPropertyRule.ts
+++ b/src/utils/createSimpleValidPropertyRule.ts
@@ -41,10 +41,10 @@ export const createSimpleValidPropertyRule = (
 					}
 				}
 
-				// If the value is an object, and has child results with issues, then report those too
 				const childrenWithIssues = result.childResults.filter(
 					(childResult) => childResult.errorMessages.length,
 				);
+				// If the value is an object, and has child results with issues, then report those too
 				if (
 					node.type === "JSONObjectExpression" &&
 					childrenWithIssues.length
@@ -52,6 +52,18 @@ export const createSimpleValidPropertyRule = (
 					for (const childResult of childrenWithIssues) {
 						const childNode = node.properties[childResult.index];
 						reportIssues(childResult, childNode);
+					}
+				}
+				// If the value is an array, and has child results with issues, then report those too
+				else if (
+					node.type === "JSONArrayExpression" &&
+					childrenWithIssues.length
+				) {
+					for (const childResult of childrenWithIssues) {
+						const childNode = node.elements[childResult.index];
+						if (childNode) {
+							reportIssues(childResult, childNode);
+						}
 					}
 				}
 			};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change incorporates the new rich output from `package-json-validator`'s `validateBin` and `validateBundleDependencies` functions, which allows us to report at a more granular level for complex objects.  We're now reporting on the individual properties of the `bin` object and individual elements of the `bundleDependencies` array, when violations occur for those items.
