### PR TITLE
feat(order-properties): lexicographically sort non-standard properties

### DIFF
--- a/docs/rules/order-properties.md
+++ b/docs/rules/order-properties.md
@@ -8,6 +8,7 @@
 
 A conventional order exists for `package.json` top-level properties.
 npm does not enforce this order, but for consistency and readability, this rule can enforce it.
+Any properties not defined in the official package.json schema are placed after the standard fields and sorted lexicographically.
 
 > 💡 This rule is especially useful in monorepos with many `package.json` files that would ideally be consistently ordered.
 
@@ -39,10 +40,9 @@ Examples of **correct** code for this rule:
 
 <!-- begin auto-generated rule options list -->
 
-| Name              | Description                                                               | Type    |
-| :---------------- | :------------------------------------------------------------------------ | :------ |
-| `order`           | Specifies the sorting order of top-level properties.                      |         |
-| `sortNonStandard` | Sort non-standard properties lexicographically after standard properties. | Boolean |
+| Name    | Description                                          |
+| :------ | :--------------------------------------------------- |
+| `order` | Specifies the sorting order of top-level properties. |
 
 <!-- end auto-generated rule options list -->
 
@@ -70,63 +70,3 @@ Pass in:
 Default: `"sort-package-json"`
 
 > ⚠️ The default value for `order` changed from `"legacy"` to `"sort-package-json"` in v0.6.0.
-
-### `sortNonStandard`
-
-The `sortNonStandard` property controls whether properties that are not in the standard order should be sorted lexicographically.
-
-When `true`, any properties not present in the chosen `order` will be sorted alphabetically and placed after all standard properties.
-When `false` (default), non-standard properties will maintain their original
-order and be placed after all standard properties.
-
-```json
-{
-	"package-json/order-properties": [
-		"error",
-		{
-			"sortNonStandard": true
-		}
-	]
-}
-```
-
-Default: `false`
-
-**Example with `sortNonStandard: true`:**
-
-Example of **incorrect** code:
-
-```json
-{
-	"b": "workspace-config",
-	"cpu": ["x64"],
-	"a": "custom",
-	"name": "my-package",
-	"version": "1.0.0"
-}
-```
-
-Example of **correct** code (non-standard properties sorted alphabetically):
-
-```json
-{
-	"name": "my-package",
-	"version": "1.0.0",
-	"cpu": ["x64"],
-	"a": "custom",
-	"b": "workspace-config"
-}
-```
-
-**Example with `sortNonStandard: false` (default):**
-
-Example of **correct** code (non-standard properties keep original order):
-
-```json
-{
-	"name": "my-package",
-	"version": "1.0.0",
-	"b": "workspace-config",
-	"a": "custom"
-}
-```

--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -46,9 +46,8 @@ export const rule = createRule({
 
 				const options = { ...context.options[0] };
 				options.order ??= "sort-package-json";
-				options.sortNonStandard ??= false;
 
-				const { order, sortNonStandard } = options;
+				const { order } = options;
 				const requiredOrder =
 					order === "legacy"
 						? standardOrderLegacy
@@ -62,9 +61,7 @@ export const rule = createRule({
 				const nonStandardKeys = allKeys.filter(
 					(key) => !requiredOrder.includes(key),
 				);
-				const orderedNonStandardKeys = sortNonStandard
-					? nonStandardKeys.sort()
-					: nonStandardKeys;
+				const orderedNonStandardKeys = nonStandardKeys.sort();
 
 				const orderedSource = sortObjectKeys(json, [
 					...requiredOrder,
@@ -119,7 +116,6 @@ export const rule = createRule({
 		defaultOptions: [
 			{
 				order: "sort-package-json",
-				sortNonStandard: false,
 			},
 		],
 		docs: {
@@ -152,11 +148,6 @@ export const rule = createRule({
 						],
 						description:
 							"Specifies the sorting order of top-level properties.",
-					},
-					sortNonStandard: {
-						description:
-							"Sort non-standard properties lexicographically after standard properties.",
-						type: "boolean",
 					},
 				},
 				type: "object",

--- a/src/tests/rules/order-properties.test.ts
+++ b/src/tests/rules/order-properties.test.ts
@@ -322,8 +322,8 @@ ruleTester.run("order-properties", rule, {
 		"type": "git",
 		"url": "git+https://github.com/fake/github.git"
 	},
-	"main": "index.js",
-	"homepage": "https://example.com"
+	"homepage": "https://example.com",
+	"main": "index.js"
 }
 `,
 		},
@@ -359,7 +359,6 @@ ruleTester.run("order-properties", rule, {
 				},
 			],
 			filename: "package.json",
-			options: [{ sortNonStandard: true }],
 			output: `{
 	"name": "sort-non-standard",
 	"version": "1.0.0",
@@ -399,7 +398,7 @@ ruleTester.run("order-properties", rule, {
 				},
 			],
 			filename: "package.json",
-			options: [{ order: "legacy", sortNonStandard: true }],
+			options: [{ order: "legacy" }],
 			output: `{
 	"name": "sort-non-standard-legacy",
 	"version": "1.0.0",
@@ -432,7 +431,7 @@ ruleTester.run("order-properties", rule, {
 				},
 			],
 			filename: "package.json",
-			options: [{ order: ["name", "version"], sortNonStandard: true }],
+			options: [{ order: ["name", "version"] }],
 			output: `{
 	"name": "custom-order-with-sort",
 	"version": "1.0.0",
@@ -527,16 +526,6 @@ ruleTester.run("order-properties", rule, {
 	"a-custom": "value",
 	"z-custom": "value"
 }`,
-			options: [{ sortNonStandard: true }],
-		},
-		{
-			code: `{
-	"name": "non-standard-not-sorted",
-	"version": "1.0.0",
-	"z-custom": "value",
-	"a-custom": "value"
-}`,
-			options: [{ sortNonStandard: false }],
 		},
 	],
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1374
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Sorts any properties that do not match a standard property lexicographically after all standard properties.