### PR TITLE
feat(valid-main): add new rule for validating `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-homepage](docs/rules/valid-homepage.md)                             | Enforce that the `homepage` property is valid.                                                              | ✔️ ✅ |    |    |    |
 | [valid-license](docs/rules/valid-license.md)                               | Enforce that the `license` property is valid.                                                               | ✔️ ✅ |    |    |    |
 | [valid-local-dependency](docs/rules/valid-local-dependency.md)             | Checks existence of local dependencies in the package.json                                                  |      |    |    | ❌  |
+| [valid-main](docs/rules/valid-main.md)                                     | Enforce that the `main` property is valid.                                                                  | ✔️ ✅ |    |    |    |
 | [valid-name](docs/rules/valid-name.md)                                     | Enforce that package names are valid npm package names                                                      | ✔️ ✅ |    |    |    |
 | [valid-optionalDependencies](docs/rules/valid-optionalDependencies.md)     | Enforce that the `optionalDependencies` property is valid.                                                  | ✔️ ✅ |    |    |    |
 | [valid-package-definition](docs/rules/valid-package-definition.md)         | Enforce that package.json has all properties required by the npm spec                                       | ✔️ ✅ |    |    |    |

--- a/docs/rules/valid-main.md
+++ b/docs/rules/valid-main.md
@@ -1,0 +1,23 @@
+# valid-main
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+This rule checks that the `main` property is a non-empty string.
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"main": ["index.js", "secondary.js"]
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"main": "index.js"
+}
+```

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -10,6 +10,7 @@ import {
 	validateExports,
 	validateHomepage,
 	validateLicense,
+	validateMain,
 	validateScripts,
 	validateType,
 } from "package-json-validator";
@@ -45,6 +46,7 @@ const properties = [
 	["exports", validateExports],
 	["homepage", validateHomepage],
 	["license", validateLicense],
+	["main", validateMain],
 	["optionalDependencies", validateDependencies],
 	["peerDependencies", validateDependencies],
 	["scripts", validateScripts],

--- a/src/tests/rules/valid-main.test.ts
+++ b/src/tests/rules/valid-main.test.ts
@@ -1,0 +1,68 @@
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.run("valid-main", rules["valid-main"], {
+	invalid: [
+		{
+			code: `{
+	"main": null
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the value is `null`, but should be a `string`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"main": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be a `string`, not `number`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"main": []
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be a `string`, not `Array`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"main": ""
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the value is empty, but should be the path to the package's main module",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: ["{}", `{ "main": "./index.js" }`, `{ "main": "index.js" }`],
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #831
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `valid-main` rule that uses `validateMain` from package-json-validator to identify errors.  It's included in the `recommended` config.
