### PR TITLE
feat(valid-os): add new rule for validating `os`

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-main](docs/rules/valid-main.md)                                     | Enforce that the `main` property is valid.                                                                  | ✔️ ✅ |    |    |    |
 | [valid-name](docs/rules/valid-name.md)                                     | Enforce that package names are valid npm package names                                                      | ✔️ ✅ |    |    |    |
 | [valid-optionalDependencies](docs/rules/valid-optionalDependencies.md)     | Enforce that the `optionalDependencies` property is valid.                                                  | ✔️ ✅ |    |    |    |
+| [valid-os](docs/rules/valid-os.md)                                         | Enforce that the `os` property is valid.                                                                    | ✔️ ✅ |    |    |    |
 | [valid-package-definition](docs/rules/valid-package-definition.md)         | Enforce that package.json has all properties required by the npm spec                                       | ✔️ ✅ |    |    |    |
 | [valid-peerDependencies](docs/rules/valid-peerDependencies.md)             | Enforce that the `peerDependencies` property is valid.                                                      | ✔️ ✅ |    |    |    |
 | [valid-private](docs/rules/valid-private.md)                               | Enforce that the `private` property is valid.                                                               | ✔️ ✅ |    |    |    |

--- a/docs/rules/valid-os.md
+++ b/docs/rules/valid-os.md
@@ -1,0 +1,29 @@
+# valid-os
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+This rule does the following checks on the value of the `os` property:
+
+- It must be an array
+- All items in the array should be one of the following: "aix", "android", "darwin", "freebsd", "linux", "openbsd", "sunos", and "win32"
+
+> [!NOTE]
+> These values are the list of possible `process.platform` values [documented by Node](https://nodejs.org/api/process.html#processplatform).
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"os": ["x64"]
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"os": ["linux", "win32"]
+}
+```

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -13,6 +13,7 @@ import {
 	validateKeywords,
 	validateLicense,
 	validateMain,
+	validateOs,
 	validatePrivate,
 	validateScripts,
 	validateType,
@@ -53,11 +54,11 @@ const properties = [
 	["license", validateLicense],
 	["main", validateMain],
 	["optionalDependencies", validateDependencies],
+	["os", validateOs],
 	["peerDependencies", validateDependencies],
 	["private", validatePrivate],
 	["scripts", validateScripts],
 	["type", validateType],
-	// TODO: More to come!
 ] satisfies [string, ValidationFunction | ValidPropertyOptions][];
 
 /** All basic valid- flavor rules */

--- a/src/tests/rules/valid-os.test.ts
+++ b/src/tests/rules/valid-os.test.ts
@@ -1,0 +1,119 @@
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.run("valid-os", rules["valid-os"], {
+	invalid: [
+		{
+			code: `{
+	"os": null
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the value is `null`, but should be an `Array` of strings",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"os": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be `Array`, not `number`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"os": "invalid"
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be `Array`, not `string`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"os": {
+      "invalid-bin": 123
+    }
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be `Array`, not `object`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"os": [
+      "invalid",
+      "",
+      123,
+      null,
+      {}
+    ]
+}
+`,
+			errors: [
+				{
+					data: {
+						error: `the value "invalid" is not valid. Valid OS values are: aix, android, darwin, freebsd, linux, openbsd, sunos, win32`,
+					},
+					line: 3,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 1 is empty, but should be the name of an operating system",
+					},
+					line: 4,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 2 should be a string, not `number`",
+					},
+					line: 5,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 3 should be a string, not `null`",
+					},
+					line: 6,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 4 should be a string, not `object`",
+					},
+					line: 7,
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: ["{}", `{ "os": [] }`, `{ "os": ["win32", "linux"] }`],
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #834
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `valid-os` rule that uses `validateOs` from package-json-validator to identify errors.  It's included in the `recommended` config.
