### PR TITLE
feat(valid-workspaces): add new rule for validating `workspaces`

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-scripts](docs/rules/valid-scripts.md)                               | Enforce that the `scripts` property is valid.                                                               | ✔️ ✅ |    |    |    |
 | [valid-type](docs/rules/valid-type.md)                                     | Enforce that the `type` property is valid.                                                                  | ✔️ ✅ |    |    |    |
 | [valid-version](docs/rules/valid-version.md)                               | Enforce that package versions are valid semver specifiers                                                   | ✔️ ✅ |    |    |    |
+| [valid-workspaces](docs/rules/valid-workspaces.md)                         | Enforce that the `workspaces` property is valid.                                                            | ✔️ ✅ |    |    |    |
 
 <!-- end auto-generated rules list -->
 <!-- prettier-ignore-end -->

--- a/docs/rules/valid-workspaces.md
+++ b/docs/rules/valid-workspaces.md
@@ -1,0 +1,26 @@
+# valid-workspaces
+
+💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+
+<!-- end auto-generated rule header -->
+
+This rule does the following checks on the value of the `workspaces` property:
+
+- It must be an array.
+- The array should only consist of non-empty strings.
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"workspaces": "./packages/*"
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"workspaces": ["./app", "./packages/*"]
+}
+```

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -20,6 +20,7 @@ import {
 	validatePublishConfig,
 	validateScripts,
 	validateType,
+	validateWorkspaces,
 } from "package-json-validator";
 
 import {
@@ -65,6 +66,7 @@ const properties = [
 	["publishConfig", validatePublishConfig],
 	["scripts", validateScripts],
 	["type", validateType],
+	["workspaces", validateWorkspaces],
 ] satisfies [string, ValidationFunction | ValidPropertyOptions][];
 
 /** All basic valid- flavor rules */

--- a/src/tests/rules/valid-workspaces.test.ts
+++ b/src/tests/rules/valid-workspaces.test.ts
@@ -1,0 +1,114 @@
+import { rules } from "../../rules/valid-properties.ts";
+import { ruleTester } from "./ruleTester.ts";
+
+ruleTester.run("valid-workspaces", rules["valid-workspaces"], {
+	invalid: [
+		{
+			code: `{
+	"workspaces": null
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the value is `null`, but should be an `Array` of strings",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"workspaces": 123
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be `Array`, not `number`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"workspaces": "invalid"
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be `Array`, not `string`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"workspaces": {}
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "the type should be `Array`, not `object`",
+					},
+					line: 2,
+					messageId: "validationError",
+				},
+			],
+		},
+		{
+			code: `{
+	"workspaces": [
+      "valid",
+      "",
+      123,
+      null,
+      {}
+    ]
+}
+`,
+			errors: [
+				{
+					data: {
+						error: "item at index 1 is empty, but should be a file path or glob pattern",
+					},
+					line: 4,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 2 should be a string, not `number`",
+					},
+					line: 5,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 3 should be a string, not `null`",
+					},
+					line: 6,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 4 should be a string, not `object`",
+					},
+					line: 7,
+					messageId: "validationError",
+				},
+			],
+		},
+	],
+	valid: [
+		"{}",
+		`{ "workspaces": [] }`,
+		`{ "workspaces": ["./app", "./packages/*"] }`,
+	],
+});


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #843
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `valid-workspaces` rule that uses `validateWorkspaces` from package-json-validator to identify errors.  It's included in the `recommended` config.
