### PR TITLE
feat: deprecate `valid-package-definition`

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [valid-name](docs/rules/valid-name.md)                                     | Enforce that package names are valid npm package names                                                      | ✔️ ✅ |    |    |    |
 | [valid-optionalDependencies](docs/rules/valid-optionalDependencies.md)     | Enforce that the `optionalDependencies` property is valid.                                                  | ✔️ ✅ |    |    |    |
 | [valid-os](docs/rules/valid-os.md)                                         | Enforce that the `os` property is valid.                                                                    | ✔️ ✅ |    |    |    |
-| [valid-package-definition](docs/rules/valid-package-definition.md)         | Enforce that package.json has all properties required by the npm spec                                       | ✔️ ✅ |    |    |    |
+| [valid-package-definition](docs/rules/valid-package-definition.md)         | Enforce that package.json has all properties required by the npm spec                                       |      |    |    | ❌  |
 | [valid-peerDependencies](docs/rules/valid-peerDependencies.md)             | Enforce that the `peerDependencies` property is valid.                                                      | ✔️ ✅ |    |    |    |
 | [valid-private](docs/rules/valid-private.md)                               | Enforce that the `private` property is valid.                                                               | ✔️ ✅ |    |    |    |
 | [valid-publishConfig](docs/rules/valid-publishConfig.md)                   | Enforce that the `publishConfig` property is valid.                                                         | ✔️ ✅ |    |    |    |

--- a/docs/rules/valid-package-definition.md
+++ b/docs/rules/valid-package-definition.md
@@ -1,6 +1,6 @@
 # valid-package-definition
 
-💼 This rule is enabled in the following configs: ✔️ `legacy-recommended`, ✅ `recommended`.
+❌ This rule is deprecated.
 
 <!-- end auto-generated rule header -->
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -53,33 +53,12 @@ const rules: Record<string, PackageJsonRuleModule> = {
 	"valid-version": validVersion,
 };
 
-const baseRecommendedRules = {
+const recommendedRules = {
 	...Object.fromEntries(
 		Object.entries(rules)
 			.filter(([, rule]) => rule.meta.docs?.recommended)
 			.map(([name]) => ["package-json/" + name, "error" as const]),
 	),
-} satisfies Linter.RulesRecord;
-
-const recommendedRules = {
-	...baseRecommendedRules,
-	// As we add more `valid-*` rules, we should prevent this legacy rule from
-	// also reporting the same errors.
-	"package-json/valid-package-definition": [
-		"error",
-		{
-			// Create a list of properties to ignore based on the valid-* rules
-			// we currently have. Once we've fully covered what `valid-package-definition`
-			// checks, we can remove it from the `recommended` config entirely.
-			ignoreProperties: Object.entries(baseRecommendedRules)
-				.filter(
-					([name]) =>
-						name.startsWith("package-json/valid-") &&
-						name !== "package-json/valid-package-definition",
-				)
-				.map(([name]) => name.replace("package-json/valid-", "")),
-		},
-	],
 } satisfies Linter.RulesRecord;
 
 const stylisticRules = {

--- a/src/rules/valid-package-definition.ts
+++ b/src/rules/valid-package-definition.ts
@@ -45,11 +45,11 @@ export const rule = createRule({
 	// eslint-disable-next-line eslint-plugin/prefer-message-ids
 	meta: {
 		defaultOptions: [{ ignoreProperties: [] }],
+		deprecated: true,
 		docs: {
 			category: "Best Practices",
 			description:
 				"Enforce that package.json has all properties required by the npm spec",
-			recommended: true,
 		},
 		schema: [
 			{


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1399
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change removes `valid-package-definition` from the `recommended` config, and marks the rule as deprecated. Now that the full set of more granular `valid-*` rules have been implemented and included in `recommended`, this monolithic rule is not longer needed.  We'll remove it entirely sometime after our 6 month deprecation period.
