### PR TITLE
feat(require-exports): add new rule to require `exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The default settings don't conflict, and Prettier plugins can quickly fix up ord
 | [require-description](docs/rules/require-description.md)                   | Requires the `description` property to be present.                                                          | ✔️ ✅ |    |    |    |
 | [require-devDependencies](docs/rules/require-devDependencies.md)           | Requires the `devDependencies` property to be present.                                                      |      |    |    |    |
 | [require-engines](docs/rules/require-engines.md)                           | Requires the `engines` property to be present.                                                              |      |    |    |    |
+| [require-exports](docs/rules/require-exports.md)                           | Requires the `exports` property to be present.                                                              |      |    |    |    |
 | [require-files](docs/rules/require-files.md)                               | Requires the `files` property to be present.                                                                |      |    |    |    |
 | [require-keywords](docs/rules/require-keywords.md)                         | Requires the `keywords` property to be present.                                                             |      |    |    |    |
 | [require-license](docs/rules/require-license.md)                           | Requires the `license` property to be present.                                                              | ✔️ ✅ |    |    |    |

--- a/docs/rules/require-exports.md
+++ b/docs/rules/require-exports.md
@@ -1,0 +1,80 @@
+# require-exports
+
+<!-- end auto-generated rule header -->
+
+This rule checks for the existence of the `"exports"` property in a package.json, and reports a violation if it doesn't exist.
+
+Example of **incorrect** code for this rule:
+
+```json
+{
+	"name": "thee-silver-mt-zion",
+	"version": "13.0.0"
+}
+```
+
+Example of **correct** code for this rule:
+
+```json
+{
+	"name": "thee-silver-mt-zion",
+	"version": "13.0.0",
+	"exports": {
+		".": "./index.js"
+	}
+}
+```
+
+## Options
+
+You can set the `ignorePrivate` option to `true` to ignore package.json `exports` with `"private": true` (default: `false`).
+
+```json
+{
+	"package-json/require-exports": [
+		"error",
+		{
+			"ignorePrivate": false
+		}
+	]
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true
+}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": false }` option:
+
+```json
+{
+	"private": true,
+	"exports": {
+		".": "./index.js"
+	}
+}
+```
+
+Example of **incorrect** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": false
+}
+```
+
+```json
+{}
+```
+
+Example of **correct** code for this rule with the `{ "ignorePrivate": true }` option:
+
+```json
+{
+	"private": true
+}
+```

--- a/src/rules/require-properties.ts
+++ b/src/rules/require-properties.ts
@@ -12,6 +12,7 @@ const properties: [name: string, options?: CreateRequirePropertyRuleOptions][] =
 		["description", { isRecommended: true }],
 		["devDependencies"],
 		["engines"],
+		["exports"],
 		["files"],
 		["keywords"],
 		["license", { ignorePrivateDefault: true, isRecommended: true }],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1409
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `require-exports` rule that, requiring that the `exports` property is present.
