### PR TITLE
build: add `files` to all eslint config objects

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -43,6 +43,29 @@ export default defineConfig(
 			regexp.configs["flat/recommended"],
 		],
 		files: JS_TS_FILES,
+		rules: {
+			// We prefer seeing :exit after all other AST selectors in rules
+			"perfectionist/sort-objects": [
+				"error",
+				{
+					customGroups: { programExit: "Program:exit" },
+					groups: ["unknown", "programExit"],
+					type: "alphabetical",
+				},
+			],
+			// Stylistic concerns that don't interfere with Prettier
+			"logical-assignment-operators": [
+				"error",
+				"always",
+				{ enforceForIfStatements: true },
+			],
+			"no-useless-rename": "error",
+			"object-shorthand": "error",
+			"operator-assignment": "error",
+		},
+		settings: {
+			perfectionist: { partitionByComment: true, type: "natural" },
+		},
 	},
 	{
 		extends: [
@@ -74,29 +97,8 @@ export default defineConfig(
 		},
 		rules: {
 			"n/no-missing-import": "off",
-
-			// We prefer seeing :exit after all other AST selectors in rules
-			"perfectionist/sort-objects": [
-				"error",
-				{
-					customGroups: { programExit: "Program:exit" },
-					groups: ["unknown", "programExit"],
-					type: "alphabetical",
-				},
-			],
-
-			// Stylistic concerns that don't interfere with Prettier
-			"logical-assignment-operators": [
-				"error",
-				"always",
-				{ enforceForIfStatements: true },
-			],
-			"no-useless-rename": "error",
-			"object-shorthand": "error",
-			"operator-assignment": "error",
 		},
 		settings: {
-			perfectionist: { partitionByComment: true, type: "natural" },
 			vitest: { typecheck: true },
 		},
 	},


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change follows the guidance from the eslint team to add `files` to all config objects in our eslint.config (except global ignores and settings).
