### PR TITLE
docs: incomplete config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,18 +149,18 @@ import packageJson from "eslint-plugin-package-json";
 import { defineConfig } from "eslint/config";
 
 export default defineConfig({
-    plugins: {
-        "package-json": packageJson,
-    },
-    rules: {
-        // `description` won't be required in package.json with `"private": true`
-        "package-json/require-description": "error",
-    },
-    settings: {
-        packageJson: {
-            enforceForPrivate: false,
-        },
-    },
+	plugins: {
+		"package-json": packageJson,
+	},
+	rules: {
+		// `description` won't be required in package.json with `"private": true`
+		"package-json/require-description": "error",
+	},
+	settings: {
+		packageJson: {
+			enforceForPrivate: false,
+		},
+	},
 });
 ```
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1451
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

In the documentation, the following works:

```ts
// eslint.config.ts
import packageJson from "eslint-plugin-package-json";

export default [
	// your other ESLint configurations
	packageJson.configs.recommended,
	{
		rules: {
			"package-json/valid-package-definition": "off",
		},
	},
];
```

But the following:

```ts
// eslint.config.ts
import packageJson from "eslint-plugin-package-json";

export default [
	// your other ESLint configurations
	packageJson.configs.recommended,
	{
		rules: {
			"package-json/valid-package-definition": "error", // "error" instead of "off"
		},
	},
];
```

raises the following error:

```
Oops! Something went wrong! :(

ESLint: 9.39.2

A configuration object specifies rule "package-json/valid-package-definition", but could not find plugin "package-json".

Common causes of this problem include:

1. The "package-json" plugin is not defined in your configuration file.
2. The "package-json" plugin is not defined within the same configuration object in which the "package-json/valid-package-definition" rule is applied.
```

To fix it, it should be embedded in eslint's `defineConfig` method and include the `files` key:
```ts
// eslint.config.ts
import packageJson from "eslint-plugin-package-json";
import { defineConfig } from "eslint/config";

export default defineConfig(
	// your other ESLint configurations
	{
		extends: [packageJson.configs.recommended],
		files: ["package.json"],
		rules: {
			"package-json/valid-package-definition": "error",
		},
	},
);
```