### PR TITLE
ci: adopt trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,14 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  id-token: write # Required for ODIC
+
 concurrency:
   group: ${{ github.workflow }}
 
@@ -14,16 +25,4 @@ jobs:
       - run: pnpm build
       - env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        uses: JoshuaKGoldberg/release-it-action@2baa12c128a42c2e8d2babb1c4984c84c8e868f7 # v0.3.5
-
-name: Release
-
-on:
-  push:
-    branches:
-      - main
-
-permissions:
-  contents: write
-  id-token: write
+        uses: JoshuaKGoldberg/release-it-action@8ee87d0d30f97b452ef5d8aa9f4d0490eed439aa # v0.4.0

--- a/.release-it.json
+++ b/.release-it.json
@@ -4,7 +4,9 @@
 		"requireCommits": true
 	},
 	"github": { "release": true, "releaseName": "v${version}" },
-	"npm": { "publishArgs": ["--access public", "--provenance"] },
+	"npm": {
+		"skipChecks": true
+	},
 	"plugins": {
 		"@release-it/conventional-changelog": {
 			"infile": "CHANGELOG.md",

--- a/package.json
+++ b/package.json
@@ -114,8 +114,5 @@
 	"packageManager": "pnpm@10.26.0",
 	"engines": {
 		"node": "^20.19.0 || >=22.12.0"
-	},
-	"publishConfig": {
-		"provenance": true
 	}
 }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1332
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change shifts to using trusted publisher. Provenance is automatically handled by the trusted publishing connection, without needing to enable it.
