### PR TITLE
chore: add typecheck to ts config files

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,4 +1,4 @@
-// @ts-expect-error - no types
+// @ts-expect-error - no types - https://github.com/eslint-community/eslint-plugin-eslint-comments/issues/214
 import comments from "@eslint-community/eslint-plugin-eslint-comments/configs";
 import eslint from "@eslint/js";
 import markdown from "@eslint/markdown";
@@ -13,7 +13,7 @@ import perfectionist from "eslint-plugin-perfectionist";
 import * as regexp from "eslint-plugin-regexp";
 import unicorn from "eslint-plugin-unicorn";
 import yml from "eslint-plugin-yml";
-import { defineConfig } from "eslint/config";
+import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 import packageJson from "./src/index.ts";
@@ -23,27 +23,25 @@ const TS_FILES = ["**/*.ts"];
 const JS_TS_FILES = [...JS_FILES, ...TS_FILES];
 
 export default defineConfig(
-	{
-		ignores: [
-			"**/*.snap",
-			".eslint-doc-generatorrc.js",
-			"coverage",
-			"docs/rules/*/*.ts",
-			"lib",
-			"node_modules",
-			"pnpm-lock.yaml",
-			"src/tests/__fixtures__",
-		],
-	},
+	globalIgnores([
+		"**/*.snap",
+		".eslint-doc-generatorrc.js",
+		"coverage",
+		"docs/rules/*/*.ts",
+		"lib",
+		"node_modules",
+		"pnpm-lock.yaml",
+		"src/tests/__fixtures__",
+	]),
 	{ linterOptions: { reportUnusedDisableDirectives: "error" } },
 	{
 		extends: [
 			eslint.configs.recommended,
-			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access -- https://github.com/eslint-community/eslint-plugin-eslint-comments/issues/214
+			// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
 			comments.recommended,
 			eslintPlugin.configs.recommended,
 			n.configs["flat/recommended"],
-			perfectionist.configs["recommended-natural"],
+			perfectionist.configs?.["recommended-natural"],
 			regexp.configs["flat/recommended"],
 			unicorn.configs.unopinionated,
 		],
@@ -124,7 +122,7 @@ export default defineConfig(
 		files: JS_TS_FILES,
 		languageOptions: {
 			parserOptions: {
-				projectService: { allowDefaultProject: ["*.config.*s"] },
+				projectService: { allowDefaultProject: ["*.config.js"] },
 				tsconfigRootDir: import.meta.dirname,
 			},
 		},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,5 @@
 		"target": "ES2024",
 		"rewriteRelativeImportExtensions": true
 	},
-	"include": ["src"]
+	"include": ["src", "*.config.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,6 @@ export default defineConfig({
 	test: {
 		clearMocks: true,
 		coverage: {
-			all: true,
 			exclude: ["lib", "src/index.ts", "src/rules/index.ts", "src/tests"],
 			include: ["src"],
 			reporter: ["html", "lcov", "text"],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

> [!NOTE]
> Actually this is a followup of #1480

## Overview

I noticed that were some typescript errors in 
- `eslint.config.ts` - `perfectionist.configs` is possibly undefined
- `vitest.config.ts` - `coverage.all` option no longer is not a valid option in `vitest@4`

To fix them I added `*.config.ts` to `tsconfig#includes` and updated `languageOptions.parserOptions.projectService` accordingly
