### PR TITLE
chore: add CHANGLOG to the prettier ignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 /coverage
 /lib
 /pnpm-lock.yaml
+/CHANGELOG.md


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds the changelog to our prettier ignore.  Since it's auto-generated by release please, we shouldn't fail builds when it's not exactly right.  In the case of Release Please PRs, it uses * for bullets instead of -, which prettier complains about.
