### PR TITLE
ci: remove PAT from release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  pull_request: ~
+  pull_request:
+    types: [labeled, opened, reopened, synchronize]
   push:
     branches:
       - main

--- a/.github/workflows/octoguide.yml
+++ b/.github/workflows/octoguide.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   octoguide:
-    if: ${{ !endsWith(github.actor, '[bot]') }}
+    if: ${{ !endsWith(github.actor, '[bot]') && !contains(github.event.pull_request.labels.*.name, 'autorelease') }}
     runs-on: ubuntu-latest
     steps:
       - uses: JoshuaKGoldberg/octoguide@879a317d50109c6446513149b381feb568364a89 # 0.18.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         id: release
-        with:
-          token: ${{ secrets.ACCESS_TOKEN }}
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         if: ${{ steps.release.outputs.release_created }}
       - uses: ./.github/actions/prepare


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Taking inspiration from `yargs`, I've updated the workflows so that the `release` workflow no longer needs a PAT.  This means CI won't automatically trigger on Release PRs anymore, but a maintainer can trigger CI by adding a `ci` label to the PR
