### PR TITLE
feat(require-attribution): add `ignorePrivate` option

### DIFF
--- a/docs/rules/require-attribution.md
+++ b/docs/rules/require-attribution.md
@@ -172,9 +172,27 @@ Examples of **correct** code for this rule with default options:
 
 | Name                     | Description                                                               | Type    |
 | :----------------------- | :------------------------------------------------------------------------ | :------ |
+| `ignorePrivate`          | Skip attribution requirements for packages with `"private": true`.        | Boolean |
 | `preferContributorsOnly` | Require that only `contributors` is present, and `author` is not defined. | Boolean |
 
 <!-- end auto-generated rule options list -->
+
+### ignorePrivate
+
+When enabled, `ignorePrivate` skips all attribution checks for packages that have `"private": true` set. This is useful for internal packages that won't be published to npm.
+
+```json
+{
+	"package-json/require-attribution": [
+		"error",
+		{
+			"ignorePrivate": true
+		}
+	]
+}
+```
+
+Default: `false`
 
 ### preferContributorsOnly
 

--- a/src/tests/rules/require-attribution.test.ts
+++ b/src/tests/rules/require-attribution.test.ts
@@ -86,6 +86,19 @@ ruleTester.run("require-attribution", rule, {
 			name: "author and contributors (preferContributorsOnly: true)",
 			options: [{ preferContributorsOnly: true }],
 		},
+		{
+			code: `{
+    "private": false
+}`,
+			errors: [
+				{
+					line: 1,
+					messageId: "missing",
+				},
+			],
+			name: "missing attribution with private: false (ignorePrivate: true)",
+			options: [{ ignorePrivate: true }],
+		},
 	],
 	valid: [
 		`{
@@ -138,5 +151,20 @@ ruleTester.run("require-attribution", rule, {
 		`{
     "author": "Trent Reznor"
 }`,
+		{
+			code: `{
+    "private": true
+}`,
+			name: "private package without attribution (ignorePrivate: true)",
+			options: [{ ignorePrivate: true }],
+		},
+		{
+			code: `{
+    "private": true,
+    "author": "Trent Reznor"
+}`,
+			name: "private package with author (ignorePrivate: true)",
+			options: [{ ignorePrivate: true }],
+		},
 	],
 });


### PR DESCRIPTION
Fixes: #1560

## PR Checklist
- [x] Addresses an existing open issue: fixes #1560
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview
This PR adds the `ignorePrivate` option to the `require-attribution` rule, allowing users to skip attribution requirements for private packages.

Changes:
- Added `ignorePrivate` option to rule schema.
- Added logic to check for `"private": true` and skip validation when enabled.
- Added test cases for the new option.
- Updated documentation.

🗂🙃