### PR TITLE
feat: add support for jsonc-eslint-parser v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"husky": "9.1.7",
 		"jiti": "2.6.1",
 		"json-schema-to-ts": "3.1.1",
-		"jsonc-eslint-parser": "2.4.1",
+		"jsonc-eslint-parser": "3.1.0",
 		"knip": "5.84.0",
 		"lint-staged": "16.2.7",
 		"prettier": "3.8.0",
@@ -106,7 +106,7 @@
 	},
 	"peerDependencies": {
 		"eslint": ">=8.0.0",
-		"jsonc-eslint-parser": "^2.0.0"
+		"jsonc-eslint-parser": ">=2.0.0"
 	},
 	"packageManager": "pnpm@10.30.0",
 	"engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1
       jsonc-eslint-parser:
-        specifier: 2.4.1
-        version: 2.4.1
+        specifier: 3.1.0
+        version: 3.1.0
       knip:
         specifier: 5.84.0
         version: 5.84.0(@types/node@24.10.1)(typescript@5.9.3)
@@ -1750,6 +1750,10 @@ packages:
   jsonc-eslint-parser@2.4.1:
     resolution: {integrity: sha512-uuPNLJkKN8NXAlZlQ6kmUF9qO+T6Kyd7oV4+/7yy8Jz6+MZNyhPq8EdLpdfnPVzUC8qSf1b4j1azKaGnFsjmsw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  jsonc-eslint-parser@3.1.0:
+    resolution: {integrity: sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4051,6 +4055,12 @@ snapshots:
       acorn: 8.15.0
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
+      semver: 7.7.3
+
+  jsonc-eslint-parser@3.1.0:
+    dependencies:
+      acorn: 8.15.0
+      eslint-visitor-keys: 5.0.0
       semver: 7.7.3
 
   keyv@4.5.4:

--- a/src/tests/rules/ruleTester.ts
+++ b/src/tests/rules/ruleTester.ts
@@ -1,5 +1,5 @@
 import { ESLint, RuleTester } from "eslint";
-import jsoncESLintParser from "jsonc-eslint-parser";
+import * as jsoncESLintParser from "jsonc-eslint-parser";
 import semver from "semver";
 import * as vitest from "vitest";
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1587
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change increases our support for `jsonc-eslint-parser` to include v3.  In v1, we'll be moving `jsonc-eslint-parser` to be a regular dependency instead of a peer dependency.  We can't do that before our node engine update, since `jsonc-eslint-parser` v3 doesn't have node 22.12.0 included in its engines.
