### PR TITLE
feat: move `jsconc-eslint-parser` to be a regular dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,11 +60,12 @@
 		"detect-indent": "^7.0.2",
 		"detect-newline": "^4.0.1",
 		"eslint-fix-utils": "~0.4.1",
+		"jsonc-eslint-parser": "^3.1.0",
 		"package-json-validator": "^1.0.1",
 		"semver": "^7.7.3",
-		"sort-object-keys": "^2.0.0",
-		"sort-package-json": "^3.4.0",
-		"validate-npm-package-name": "^7.0.0"
+		"sort-object-keys": "^2.1.0",
+		"sort-package-json": "^3.6.1",
+		"validate-npm-package-name": "^7.0.2"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.6.0",
@@ -92,7 +93,6 @@
 		"husky": "9.1.7",
 		"jiti": "2.6.1",
 		"json-schema-to-ts": "3.1.1",
-		"jsonc-eslint-parser": "3.1.0",
 		"knip": "5.84.0",
 		"lint-staged": "16.2.7",
 		"prettier": "3.8.0",
@@ -105,8 +105,7 @@
 		"vitest": "4.0.13"
 	},
 	"peerDependencies": {
-		"eslint": ">=9.0.0",
-		"jsonc-eslint-parser": ">=2.0.0"
+		"eslint": ">=9.0.0"
 	},
 	"packageManager": "pnpm@10.30.0",
 	"engines": {

--- a/package.json
+++ b/package.json
@@ -63,9 +63,9 @@
 		"jsonc-eslint-parser": "^3.1.0",
 		"package-json-validator": "^1.0.1",
 		"semver": "^7.7.3",
-		"sort-object-keys": "^2.1.0",
-		"sort-package-json": "^3.6.1",
-		"validate-npm-package-name": "^7.0.2"
+		"sort-object-keys": "^2.0.0",
+		"sort-package-json": "^3.4.0",
+		"validate-npm-package-name": "^7.0.0"
 	},
 	"devDependencies": {
 		"@eslint-community/eslint-plugin-eslint-comments": "4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,13 +33,13 @@ importers:
         specifier: ^7.7.3
         version: 7.7.4
       sort-object-keys:
-        specifier: ^2.1.0
+        specifier: ^2.0.0
         version: 2.1.0
       sort-package-json:
-        specifier: ^3.6.1
+        specifier: ^3.4.0
         version: 3.6.1
       validate-npm-package-name:
-        specifier: ^7.0.2
+        specifier: ^7.0.0
         version: 7.0.2
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint-fix-utils:
         specifier: ~0.4.1
         version: 0.4.1(@types/estree@1.0.8)(eslint@10.0.0(jiti@2.6.1))
+      jsonc-eslint-parser:
+        specifier: ^3.1.0
+        version: 3.1.0
       package-json-validator:
         specifier: ^1.0.1
         version: 1.0.1
@@ -30,13 +33,13 @@ importers:
         specifier: ^7.7.3
         version: 7.7.4
       sort-object-keys:
-        specifier: ^2.0.0
+        specifier: ^2.1.0
         version: 2.1.0
       sort-package-json:
-        specifier: ^3.4.0
+        specifier: ^3.6.1
         version: 3.6.1
       validate-npm-package-name:
-        specifier: ^7.0.0
+        specifier: ^7.0.2
         version: 7.0.2
     devDependencies:
       '@eslint-community/eslint-plugin-eslint-comments':
@@ -114,9 +117,6 @@ importers:
       json-schema-to-ts:
         specifier: 3.1.1
         version: 3.1.1
-      jsonc-eslint-parser:
-        specifier: 3.1.0
-        version: 3.1.0
       knip:
         specifier: 5.84.0
         version: 5.84.0(@types/node@24.10.1)(typescript@5.9.3)


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1588
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change moves `jsonc-eslint-parser` from being a peer dependency to being a regular dependency.  If you're using one of our configs, and not configuring the parser yourself, you can safely remove this as a dependency from your project.
