### PR TITLE
fix(valid-publishConfig): rule not reporting violations for deeply nested objects

### DIFF
--- a/src/tests/rules/valid-publishConfig.test.ts
+++ b/src/tests/rules/valid-publishConfig.test.ts
@@ -82,9 +82,37 @@ ruleTester.run("valid-publishConfig", rules["valid-publishConfig"], {
 				},
 				{
 					data: {
+						error: "item at index 0 is empty, but should be the name of a CPU architecture",
+					},
+					line: 5,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "item at index 1 is empty, but should be the name of a CPU architecture",
+					},
+					line: 5,
+					messageId: "validationError",
+				},
+				{
+					data: {
 						error: "the value is empty, but should be the path to a subdirectory",
 					},
 					line: 6,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "property 0 has an empty key, but should be an export condition",
+					},
+					line: 8,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: 'the value of "./secondary" is empty, but should be an entry point path',
+					},
+					line: 9,
 					messageId: "validationError",
 				},
 				{
@@ -154,6 +182,20 @@ ruleTester.run("valid-publishConfig", rules["valid-publishConfig"], {
 						error: "the type should be a `string`, not `number`",
 					},
 					line: 6,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "the value of property 0 should be either an entry point path or an object of export conditions",
+					},
+					line: 8,
+					messageId: "validationError",
+				},
+				{
+					data: {
+						error: "property 0 has an empty key, but should be an export condition",
+					},
+					line: 8,
 					messageId: "validationError",
 				},
 				{

--- a/src/utils/createSimpleValidPropertyRule.ts
+++ b/src/utils/createSimpleValidPropertyRule.ts
@@ -49,7 +49,7 @@ export const createSimpleValidPropertyRule = (
 				) {
 					for (const childResult of childrenWithIssues) {
 						const childNode = node.properties[childResult.index];
-						reportIssues(childResult, childNode);
+						reportIssues(childResult, childNode.value);
 					}
 				}
 				// If the value is an array, and has child results with issues, then report those too


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1661
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change addresses a bug I found while implementing `valid-devEngines`, where objects with more than two levels of nesting were not properly reporting violations returned from pjv at those deeper levels.  This likely also impacted `valid-exports`
