### PR TITLE
fix(no-empty-fields): #1679 Allow `files` to be an empty list

### DIFF
--- a/docs/rules/no-empty-fields.md
+++ b/docs/rules/no-empty-fields.md
@@ -9,13 +9,15 @@
 This rule flags all empty arrays and objects in a `package.json`, as such empty expressions do nothing, and are often the result of a mistake.
 It will report both named properties that are empty, as well as nested arrays and objects that are empty.
 
+Exceptions include the `files` property, which can be left empty as the files can be inferred; see `no-redundant-files`
+
 Example of **incorrect** code for this rule:
 
 ```json
 {
 	"main": "lib/index.js",
 	"scripts": {},
-	"files": [],
+	"browserlist": [],
 	"simple-git-hooks": {
 		"pre-commit": "pnpm exec nano-staged --allow-empty",
 		"preserveUnused": []

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -94,9 +94,14 @@ const getTopLevelProperty = (
 		: undefined;
 };
 
+// `files` can be empty since its contents can be inferred by `npm pack`
+const exceptions = ["files"];
+
 export const rule = createRule({
 	create(context) {
-		const ignoreProperties = context.options[0]?.ignoreProperties ?? [];
+		const ignoreProperties = new Set(
+			exceptions.concat(context.options[0]?.ignoreProperties ?? []),
+		);
 
 		return {
 			JSONArrayExpression(node) {
@@ -107,7 +112,7 @@ export const rule = createRule({
 				}
 				if (!node.elements.length) {
 					const topLevelPropertyName = topLevelProperty.value;
-					if (!ignoreProperties.includes(topLevelPropertyName)) {
+					if (!ignoreProperties.has(topLevelPropertyName)) {
 						report(context, getNode(node));
 					}
 				}
@@ -120,7 +125,7 @@ export const rule = createRule({
 				}
 				if (!node.properties.length) {
 					const topLevelPropertyName = topLevelProperty.value;
-					if (!ignoreProperties.includes(topLevelPropertyName)) {
+					if (!ignoreProperties.has(topLevelPropertyName)) {
 						report(context, getNode(node));
 					}
 				}

--- a/src/tests/rules/no-empty-fields.test.ts
+++ b/src/tests/rules/no-empty-fields.test.ts
@@ -6,7 +6,7 @@ ruleTester.run("no-empty-fields", rule, {
 		{
 			code: `{
 \t\t"name": "test",
-\t\t"files": [],
+\t\t"workspaces": [],
 \t\t"dependencies": {
 \t\t\t\t"@altano/repository-tools": "^0.1.1"
 \t\t}
@@ -14,7 +14,7 @@ ruleTester.run("no-empty-fields", rule, {
 `,
 			errors: [
 				{
-					data: { field: "files" },
+					data: { field: "workspaces" },
 					messageId: "emptyFields",
 					suggestions: [
 						{
@@ -259,7 +259,7 @@ ruleTester.run("no-empty-fields", rule, {
 		{
 			code: `{
 \t\t"name": "test",
-\t\t"files": [],
+\t\t"workspaces": [],
 \t\t"dependencies": {
 \t\t\t\t"@altano/repository-tools": "^0.1.1",
 \t\t\t\t"test": []
@@ -268,7 +268,7 @@ ruleTester.run("no-empty-fields", rule, {
 `,
 			errors: [
 				{
-					data: { field: "files" },
+					data: { field: "workspaces" },
 					messageId: "emptyFields",
 					suggestions: [
 						{
@@ -293,7 +293,7 @@ ruleTester.run("no-empty-fields", rule, {
 							messageId: "remove",
 							output: `{
 \t\t"name": "test",
-\t\t"files": [],
+\t\t"workspaces": [],
 \t\t"dependencies": {
 \t\t\t\t"@altano/repository-tools": "^0.1.1"
 \t\t\t\t
@@ -308,14 +308,14 @@ ruleTester.run("no-empty-fields", rule, {
 		{
 			code: `{
 \t\t"name": "test",
-\t\t"files": [],
+\t\t"workspaces": [],
 \t\t"browserslist": [],
 \t\t"scripts": {}
 }
 `,
 			errors: [
 				{
-					data: { field: "files" },
+					data: { field: "workspaces" },
 					messageId: "emptyFields",
 					suggestions: [
 						{
@@ -338,7 +338,7 @@ ruleTester.run("no-empty-fields", rule, {
 							messageId: "remove",
 							output: `{
 \t\t"name": "test",
-\t\t"files": [],
+\t\t"workspaces": [],
 \t\t"browserslist": []
 \t\t
 }
@@ -391,6 +391,7 @@ ruleTester.run("no-empty-fields", rule, {
 	valid: [
 		`{}`,
 		`[]`,
+		`{ "name": "test", "files": [] }`,
 		`{ "name": "test", "files": ["index.js"] }`,
 		`{ "name": "test", "peerDependencies": { "eslint": ">=8.0.0" } }`,
 		`{ "name": "test", "dependencies": { "eslint": ">=8.0.0" } }`,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1679
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adding `files` as an exception to the `no-empty-fields` rule, since in some cases it can be correctly left empty (and not clash with `no-redundant-files`) 
