### PR TITLE
feat(order-properties)!: remove `legacy` order option

### DIFF
--- a/docs/rules/order-properties.md
+++ b/docs/rules/order-properties.md
@@ -51,10 +51,9 @@ Examples of **correct** code for this rule:
 The `order` property specifies the sorting order of package properties.
 Pass in:
 
-- `"legacy"` - to order properties specified by [npm documentation](https://docs.npmjs.com/cli/v10/configuring-npm/package-json).
 - `"sort-package-json"` - to order properties by the default order specified in [sort-package-json](https://github.com/keithamus/sort-package-json).
 - `Array<string>` - to specify an array of top-level package properties to lint sorting on only those properties.
-  All properties not in this collection will be sorted by "sort-package-json" specifications.
+  All properties not in this collection will be sorted by "sort-package-json" specification.
 
 ```json
 {
@@ -66,7 +65,3 @@ Pass in:
 	]
 }
 ```
-
-Default: `"sort-package-json"`
-
-> ⚠️ The default value for `order` changed from `"legacy"` to `"sort-package-json"` in v0.6.0.

--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -7,53 +7,17 @@ import { sortOrder } from "sort-package-json";
 
 import { createRule } from "../createRule.ts";
 
-const standardOrderLegacy = [
-	"name",
-	"version",
-	"private",
-	"publishConfig",
-	"description",
-	"main",
-	"exports",
-	"browser",
-	"files",
-	"bin",
-	"directories",
-	"man",
-	"scripts",
-	"repository",
-	"keywords",
-	"author",
-	"license",
-	"bugs",
-	"homepage",
-	"config",
-	"dependencies",
-	"devDependencies",
-	"peerDependencies",
-	"optionalDependencies",
-	"bundledDependencies",
-	"engines",
-	"os",
-	"cpu",
-];
-
 export const rule = createRule({
 	create(context) {
 		return {
 			"Program:exit"() {
 				const { ast, text } = context.sourceCode;
 
-				const options = { ...context.options[0] };
-				options.order ??= "sort-package-json";
+				const { order = "sort-package-json" } =
+					context.options[0] ?? {};
 
-				const { order } = options;
 				const requiredOrder =
-					order === "legacy"
-						? standardOrderLegacy
-						: order === "sort-package-json"
-							? sortOrder
-							: order;
+					order === "sort-package-json" ? sortOrder : order;
 
 				const json = JSON.parse(text) as Record<string, unknown>;
 
@@ -134,7 +98,7 @@ export const rule = createRule({
 					order: {
 						anyOf: [
 							{
-								enum: ["legacy", "sort-package-json"],
+								enum: ["sort-package-json"],
 								type: ["string"],
 							},
 							{

--- a/src/tests/rules/order-properties.test.ts
+++ b/src/tests/rules/order-properties.test.ts
@@ -236,55 +236,7 @@ ruleTester.run("order-properties", rule, {
 	"main": "index.js",
 	"homepage": "https://example.com",
 	"version": "1.0.0",
-	"name": "order-legacy",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/fake/github.git"
-	}
-}
-`,
-			errors: [
-				{
-					data: { property: "main" },
-					messageId: "incorrectOrder",
-				},
-				{
-					data: { property: "homepage" },
-					messageId: "incorrectOrder",
-				},
-				{
-					data: { property: "version" },
-					messageId: "incorrectOrder",
-				},
-				{
-					data: { property: "name" },
-					messageId: "incorrectOrder",
-				},
-				{
-					data: { property: "repository" },
-					messageId: "incorrectOrder",
-				},
-			],
-			filename: "package.json",
-			options: [{ order: "legacy" }],
-			output: `{
-	"name": "order-legacy",
-	"version": "1.0.0",
-	"main": "index.js",
-	"repository": {
-		"type": "git",
-		"url": "git+https://github.com/fake/github.git"
-	},
-	"homepage": "https://example.com"
-}
-`,
-		},
-		{
-			code: `{
-	"main": "index.js",
-	"homepage": "https://example.com",
-	"version": "1.0.0",
-	"name": "order-legacy",
+	"name": "order-custom",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/fake/github.git"
@@ -317,7 +269,7 @@ ruleTester.run("order-properties", rule, {
 			options: [{ order: ["version", "name", "repository"] }],
 			output: `{
 	"version": "1.0.0",
-	"name": "order-legacy",
+	"name": "order-custom",
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/fake/github.git"
@@ -367,44 +319,6 @@ ruleTester.run("order-properties", rule, {
 	],
 	"a": "custom",
 	"b": "workspace-config"
-}
-`,
-		},
-		{
-			code: `{
-	"z": "last",
-	"name": "sort-non-standard-legacy",
-	"a": "first",
-	"version": "1.0.0",
-	"m": "middle"
-}
-`,
-			errors: [
-				{
-					data: { property: "z" },
-					messageId: "incorrectOrder",
-				},
-				{
-					data: { property: "name" },
-					messageId: "incorrectOrder",
-				},
-				{
-					data: { property: "version" },
-					messageId: "incorrectOrder",
-				},
-				{
-					data: { property: "m" },
-					messageId: "incorrectOrder",
-				},
-			],
-			filename: "package.json",
-			options: [{ order: "legacy" }],
-			output: `{
-	"name": "sort-non-standard-legacy",
-	"version": "1.0.0",
-	"a": "first",
-	"m": "middle",
-	"z": "last"
 }
 `,
 		},
@@ -512,19 +426,6 @@ ruleTester.run("order-properties", rule, {
 }
 `,
 			options: [{ order: "sort-package-json" }],
-		},
-		{
-			code: `{
-	"name": "treat-yo-self",
-	"version": "1.1.1",
-	"description": "Once a year.",
-	"main": "index.js",
-	"exports": {
-		"import": "./index.js",
-		"require": "./index.js"
-	}
-}`,
-			options: [{ order: "legacy" }],
 		},
 		{
 			code: `{


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1700
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Only `sort-package-json` and a custom array ordering are valid options for `order` now.

BEGIN_COMMIT_OVERRIDE
feat(order-properties)!: remove legacy order option
END_COMMIT_OVERRIDE
