### PR TITLE
docs: correct `require-sideEffects` usage example

### DIFF
--- a/docs/rules/require-sideEffects.md
+++ b/docs/rules/require-sideEffects.md
@@ -37,7 +37,7 @@ Example of **correct** code for this rule:
 
 ```json
 {
-	"package-json/require-files": [
+	"package-json/require-sideEffects": [
 		"error",
 		{
 			"ignorePrivate": false


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1716
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Diff is hopefully simple enough - just corrects the usage example for `require-sideEffects` in the docs.

❤️ (yes, I read the pr guidelines 😄)
