### PR TITLE
fix(valid-dependencies): dependencies should be able to use disttags

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
 		"detect-indent": "^7.0.2",
 		"detect-newline": "^4.0.1",
 		"eslint-fix-utils": "~0.4.1",
-		"package-json-validator": "^1.3.1",
+		"package-json-validator": "^1.4.1",
 		"semver": "^7.7.3",
 		"sort-object-keys": "^2.0.0",
 		"sort-package-json": "^3.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ~0.4.1
         version: 0.4.2(@types/estree@1.0.8)(eslint@10.2.0(jiti@2.6.1))
       package-json-validator:
-        specifier: ^1.3.1
-        version: 1.4.0
+        specifier: ^1.4.1
+        version: 1.4.1
       semver:
         specifier: ^7.7.3
         version: 7.7.4
@@ -3167,8 +3167,8 @@ packages:
     resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
     engines: {node: '>=20'}
 
-  package-json-validator@1.4.0:
-    resolution: {integrity: sha512-Nb1qg9Z7Om/r3kw3gZfKbFvFC6e0Cj38Zc5NS2LCogxqbUCbFLTjlvRKk/9doMvaAyrzUVwrR0si/opLru4CHw==}
+  package-json-validator@1.4.1:
+    resolution: {integrity: sha512-kH0EKKflJOfYQeiANow4FkVn2yXVUdxPxtcSiAWSBOVXNopDBdPUShTKGVGy8Dln3n0dZZUETe0p1wGyUQGwBw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   package-json@10.0.1:
@@ -7410,8 +7410,9 @@ snapshots:
 
   p-timeout@7.0.1: {}
 
-  package-json-validator@1.4.0:
+  package-json-validator@1.4.1:
     dependencies:
+      npm-package-arg: 13.0.2
       semver: 7.7.4
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 7.0.2

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -76,38 +76,27 @@ ruleTester.run("valid-dependencies", rules["valid-dependencies"], {
 `,
 			errors: [
 				{
+					column: 18,
 					data: {
-						error: "invalid version range for dependency david: bowie",
-					},
-					line: 3,
-					messageId: "validationError",
-				},
-				{
-					data: {
-						error: "dependency version for trent should be a string: 123",
+						error: "dependency version for `trent` should be a string: 123",
 					},
 					line: 4,
 					messageId: "validationError",
 				},
 				{
+					column: 24,
 					data: {
-						error: "dependency version for the-fragile should be a string: null",
+						error: "dependency version for `the-fragile` should be a string: null",
 					},
 					line: 5,
 					messageId: "validationError",
 				},
 				{
+					column: 23,
 					data: {
-						error: "dependency version for pink-floyd should be a string: [object Object]",
+						error: "dependency version for `pink-floyd` should be a string: [object Object]",
 					},
 					line: 6,
-					messageId: "validationError",
-				},
-				{
-					data: {
-						error: "invalid version range for dependency childish-gambino: workspace",
-					},
-					line: 7,
 					messageId: "validationError",
 				},
 			],
@@ -126,7 +115,8 @@ ruleTester.run("valid-dependencies", rules["valid-dependencies"], {
     "alt-j": "workspace:~",
     "run-the-jewels": "workspace:*",
     "thee-silver-mt-zion": "workspace:^1.2.3",
-    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+    "efrim-manuel-menuck": "npm:bar@^1.0.0",
+    "jessica-moss": "beta"
   }
 }`,
 		`{ "dependencies": {} }`,

--- a/src/tests/rules/valid-devDependencies.test.ts
+++ b/src/tests/rules/valid-devDependencies.test.ts
@@ -76,38 +76,27 @@ ruleTester.run("valid-devDependencies", rules["valid-devDependencies"], {
 `,
 			errors: [
 				{
+					column: 18,
 					data: {
-						error: "invalid version range for dependency david: bowie",
-					},
-					line: 3,
-					messageId: "validationError",
-				},
-				{
-					data: {
-						error: "dependency version for trent should be a string: 123",
+						error: "dependency version for `trent` should be a string: 123",
 					},
 					line: 4,
 					messageId: "validationError",
 				},
 				{
+					column: 24,
 					data: {
-						error: "dependency version for the-fragile should be a string: null",
+						error: "dependency version for `the-fragile` should be a string: null",
 					},
 					line: 5,
 					messageId: "validationError",
 				},
 				{
+					column: 23,
 					data: {
-						error: "dependency version for pink-floyd should be a string: [object Object]",
+						error: "dependency version for `pink-floyd` should be a string: [object Object]",
 					},
 					line: 6,
-					messageId: "validationError",
-				},
-				{
-					data: {
-						error: "invalid version range for dependency childish-gambino: workspace",
-					},
-					line: 7,
 					messageId: "validationError",
 				},
 			],
@@ -126,7 +115,8 @@ ruleTester.run("valid-devDependencies", rules["valid-devDependencies"], {
     "alt-j": "workspace:~",
     "run-the-jewels": "workspace:*",
     "thee-silver-mt-zion": "workspace:^1.2.3",
-    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+    "efrim-manuel-menuck": "npm:bar@^1.0.0",
+    "jessica-moss": "beta"
   }
 }`,
 		`{ "devDependencies": {} }`,

--- a/src/tests/rules/valid-optionalDependencies.test.ts
+++ b/src/tests/rules/valid-optionalDependencies.test.ts
@@ -79,38 +79,27 @@ ruleTester.run(
 `,
 				errors: [
 					{
+						column: 18,
 						data: {
-							error: "invalid version range for dependency david: bowie",
-						},
-						line: 3,
-						messageId: "validationError",
-					},
-					{
-						data: {
-							error: "dependency version for trent should be a string: 123",
+							error: "dependency version for `trent` should be a string: 123",
 						},
 						line: 4,
 						messageId: "validationError",
 					},
 					{
+						column: 24,
 						data: {
-							error: "dependency version for the-fragile should be a string: null",
+							error: "dependency version for `the-fragile` should be a string: null",
 						},
 						line: 5,
 						messageId: "validationError",
 					},
 					{
+						column: 23,
 						data: {
-							error: "dependency version for pink-floyd should be a string: [object Object]",
+							error: "dependency version for `pink-floyd` should be a string: [object Object]",
 						},
 						line: 6,
-						messageId: "validationError",
-					},
-					{
-						data: {
-							error: "invalid version range for dependency childish-gambino: workspace",
-						},
-						line: 7,
 						messageId: "validationError",
 					},
 				],
@@ -129,7 +118,8 @@ ruleTester.run(
     "alt-j": "workspace:~",
     "run-the-jewels": "workspace:*",
     "thee-silver-mt-zion": "workspace:^1.2.3",
-    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+    "efrim-manuel-menuck": "npm:bar@^1.0.0",
+    "jessica-moss": "beta"
   }
 }`,
 			`{ "optionalDependencies": {} }`,

--- a/src/tests/rules/valid-peerDependencies.test.ts
+++ b/src/tests/rules/valid-peerDependencies.test.ts
@@ -76,38 +76,27 @@ ruleTester.run("valid-peerDependencies", rules["valid-peerDependencies"], {
 `,
 			errors: [
 				{
+					column: 18,
 					data: {
-						error: "invalid version range for dependency david: bowie",
-					},
-					line: 3,
-					messageId: "validationError",
-				},
-				{
-					data: {
-						error: "dependency version for trent should be a string: 123",
+						error: "dependency version for `trent` should be a string: 123",
 					},
 					line: 4,
 					messageId: "validationError",
 				},
 				{
+					column: 24,
 					data: {
-						error: "dependency version for the-fragile should be a string: null",
+						error: "dependency version for `the-fragile` should be a string: null",
 					},
 					line: 5,
 					messageId: "validationError",
 				},
 				{
+					column: 23,
 					data: {
-						error: "dependency version for pink-floyd should be a string: [object Object]",
+						error: "dependency version for `pink-floyd` should be a string: [object Object]",
 					},
 					line: 6,
-					messageId: "validationError",
-				},
-				{
-					data: {
-						error: "invalid version range for dependency childish-gambino: workspace",
-					},
-					line: 7,
 					messageId: "validationError",
 				},
 			],
@@ -126,7 +115,8 @@ ruleTester.run("valid-peerDependencies", rules["valid-peerDependencies"], {
     "alt-j": "workspace:~",
     "run-the-jewels": "workspace:*",
     "thee-silver-mt-zion": "workspace:^1.2.3",
-    "efrim-manuel-menuck": "npm:bar@^1.0.0"
+    "efrim-manuel-menuck": "npm:bar@^1.0.0",
+    "jessica-moss": "beta"
   }
 }`,
 		`{ "peerDependencies": {} }`,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates `package-json-validator` to the version that includes a fix for `validateDependencies` (1.4.1) to allow for versions to be declared with disttags.  This affects all four variations of the `dependencies` rules.

- `valid-dependencies`
- `valid-devDependencies`
- `valid-optionalDependencies`
- `valid-peerDependencies`

Tests needed to be updated accordingly.

Thanks @andreww2012 