### PR TITLE
chore: update Release Please config for v1 release

### DIFF
--- a/.github/release-please/release-please-config.main.json
+++ b/.github/release-please/release-please-config.main.json
@@ -1,6 +1,4 @@
 {
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "changelog-sections": [
     { "type": "feat", "section": "🚀 Features", "hidden": false },
     { "type": "fix", "section": "🩹 Bug Fixes", "hidden": false },


### PR DESCRIPTION
This change removes the pre-major settings from our Release Please config, in preparation for our upcoming v1 release.  

_This should be merged just before merging the `beta` branch into `main`._

Release-As: 1.0.0
