### PR TITLE
docs: enable eslint-doc-generator patch to create new frontmatter

### DIFF
--- a/patches/eslint-doc-generator.patch
+++ b/patches/eslint-doc-generator.patch
@@ -290,7 +290,7 @@ index 4006d82950f917764c4579dcfdd3aa9528bbdd13..ecef9c8220f7efc8e56b56d1dec2c488
      // eslint-disable-next-line unicorn/no-instanceof-builtins
      stringOrArray instanceof Array
 diff --git a/dist/lib/rule-doc-notices.js b/dist/lib/rule-doc-notices.js
-index d0be6f003c1c3bbae5a89c18e6b428dd297ca229..fd6d47faa948208ddeb5c93d9151536436985b30 100644
+index d0be6f003c1c3bbae5a89c18e6b428dd297ca229..28f56de5f5d2fed61016045bb663a126f2c49335 100644
 --- a/dist/lib/rule-doc-notices.js
 +++ b/dist/lib/rule-doc-notices.js
 @@ -1,5 +1,5 @@
@@ -342,7 +342,7 @@ index d0be6f003c1c3bbae5a89c18e6b428dd297ca229..fd6d47faa948208ddeb5c93d91515364
          }
          /* istanbul ignore next -- this shouldn't happen */
          default: {
-@@ -332,16 +332,43 @@ function makeRuleDocTitle(context, name, description) {
+@@ -332,16 +332,70 @@ function makeRuleDocTitle(context, name, description) {
          }
      }
  }
@@ -357,15 +357,42 @@ index d0be6f003c1c3bbae5a89c18e6b428dd297ca229..fd6d47faa948208ddeb5c93d91515364
 +    return oldFrontmatterLines;
 +  }
 +
++  // If there is currently no frontmatter, then create a new one with the title and description.
++  if (oldFrontmatterLines.length === 0) {
++    const newFrontmatter = [
++      '---',
++      `title: ${title}`
++    ];
++    if (description) {
++      newFrontmatter.push(`description: ${description}`);
++    }
++    newFrontmatter.push('---');
++    return newFrontmatter;
++  }
++
 +  const newFrontmatter = [];
++  let titleSeen = false;
++  let descriptionSeen = false;
 +  for (const line of oldFrontmatterLines) {
 +    if (line.startsWith('title:')) {
 +      newFrontmatter.push(`title: ${title}`);
++      titleSeen = true;
 +    } else if (line.startsWith('description:') && description) {
 +      newFrontmatter.push(`description: ${description}`);
++      descriptionSeen = true;
 +    } else {
 +      newFrontmatter.push(line);
 +    }
++  }
++
++  // If the old frontmatter didn't have a title, then add it to the beginning of the frontmatter (after the opening ---).
++  if (!titleSeen) {
++    newFrontmatter.splice(1, 0, `title: ${title}`);
++  }
++  // If the old frontmatter didn't have a description but we have one, then add it after the title.
++  if (description && !descriptionSeen) {
++    const titleIndex = newFrontmatter.findIndex(line => line.startsWith('title:'));
++    newFrontmatter.splice(titleIndex + 1, 0, `description: ${description}`);
 +  }
 +  return newFrontmatter;
 +}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   eslint-doc-generator:
-    hash: f3fdfd867694e624275965b8e46cd9dcca4a8167998c71f173be5451cde15c8a
+    hash: d85889406c6d57ac48ae3ac9ebb762236ae4039a8b06eec24b4151fbceb91dff
     path: patches/eslint-doc-generator.patch
 
 importers:
@@ -88,7 +88,7 @@ importers:
         version: 10.3.0(jiti@2.6.1)
       eslint-doc-generator:
         specifier: 3.3.1
-        version: 3.3.1(patch_hash=f3fdfd867694e624275965b8e46cd9dcca4a8167998c71f173be5451cde15c8a)(eslint@10.3.0(jiti@2.6.1))(prettier@3.8.0)(typescript@6.0.2)
+        version: 3.3.1(patch_hash=d85889406c6d57ac48ae3ac9ebb762236ae4039a8b06eec24b4151fbceb91dff)(eslint@10.3.0(jiti@2.6.1))(prettier@3.8.0)(typescript@6.0.2)
       eslint-plugin-eslint-plugin:
         specifier: 7.3.1
         version: 7.3.1(eslint@10.3.0(jiti@2.6.1))
@@ -5725,7 +5725,7 @@ snapshots:
       eslint: 10.3.0(jiti@2.6.1)
       semver: 7.7.4
 
-  eslint-doc-generator@3.3.1(patch_hash=f3fdfd867694e624275965b8e46cd9dcca4a8167998c71f173be5451cde15c8a)(eslint@10.3.0(jiti@2.6.1))(prettier@3.8.0)(typescript@6.0.2):
+  eslint-doc-generator@3.3.1(patch_hash=d85889406c6d57ac48ae3ac9ebb762236ae4039a8b06eec24b4151fbceb91dff)(eslint@10.3.0(jiti@2.6.1))(prettier@3.8.0)(typescript@6.0.2):
     dependencies:
       '@typescript-eslint/utils': 8.59.1(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.2)
       ajv: 8.20.0


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The patch I added in #1787 provided the ability to keep frontmatter in sync, but didn't include generating new front matter when pages didn't already have it (like in the case of creating all new doc pages with `--init-rule-docs`.  This change adds that in.  It also will now _add_ `title` and / or `description` if we have values of those and they're not already in the existing frontmatter.