### PR TITLE
chore: add `sharp` back

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "prettier-plugin-packagejson": "3.0.0",
     "prettier-plugin-sentences-per-line": "0.2.3",
     "prettier-plugin-sh": "0.18.0",
+    "sharp": "^0.34.5",
     "tsdown": "0.22.0",
     "typescript": "6.0.2",
     "typescript-eslint": "8.59.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ importers:
       prettier-plugin-sh:
         specifier: 0.18.0
         version: 0.18.0(prettier@3.8.0)
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       tsdown:
         specifier: 0.22.0
         version: 0.22.0(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(typescript@6.0.2)
@@ -4241,8 +4244,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
@@ -5407,8 +5409,7 @@ snapshots:
 
   detect-indent@7.0.2: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-newline@4.0.1: {}
 
@@ -7495,7 +7496,6 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
It seems we need to install `sharp` locally, to satisfy `astro`'s optional dependency.  Even though local builds and CI builds are still pulling it in ok, the builds in cloudflare are failing without it.

