### PR TITLE
ci: add additional versions of node to our test matrix

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,7 @@ runs:
     # - run: pnpm config set --location=project strictEngines true
     #   if: ${{ inputs.strict-engines == 'true' }}
     #   shell: bash
-    - run: pnpm install --strict-engines
+    - run: pnpm install --config.strictEngines=true
       if: ${{ inputs.strict-engines == 'true' }}
       shell: bash
     - run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,8 +7,8 @@ inputs:
     description: Node.js version to use
     default: "lts/*"
     required: false
-  strict-peers:
-    description: Whether to use strict peer dependency resolution
+  strict-engines:
+    description: Whether to use strict engine compatibility checks
     default: false
     required: false
 
@@ -18,6 +18,9 @@ runs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.node-version }}
-    - run: pnpm install --frozen-lockfile --strict-peer-dependencies=${{ inputs.strict-peers }}
+    - run: pnpm config set --location=project strictEngines true
+      if: ${{ inputs.strict-engines == 'true' }}
+      shell: bash
+    - run: pnpm install --frozen-lockfile
       shell: bash
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,6 @@ runs:
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
-        cache: pnpm
         node-version: ${{ inputs.node-version }}
     - run: pnpm config set --location=project strictPeerDependencies true
       if: ${{ inputs.strict-peers == 'true' }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,6 +21,7 @@ runs:
         node-version: ${{ inputs.node-version }}
     - run: pnpm config set strictPeerDependencies true
       if: ${{ inputs.strict-peers == 'true' }}
+      shell: bash
     - run: pnpm install --frozen-lockfile
       shell: bash
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,9 +18,13 @@ runs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.node-version }}
-    - run: pnpm config set --location=project strictEngines true
+    # - run: pnpm config set --location=project strictEngines true
+    #   if: ${{ inputs.strict-engines == 'true' }}
+    #   shell: bash
+    - run: pnpm install --strict-engines
       if: ${{ inputs.strict-engines == 'true' }}
       shell: bash
     - run: pnpm install --frozen-lockfile
+      if: ${{ inputs.strict-engines == 'false' }}
       shell: bash
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,6 +13,7 @@ runs:
     - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
+        cache: pnpm
         node-version: ${{ inputs.node-version }}
     - run: pnpm install --frozen-lockfile
       shell: bash

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,13 +18,13 @@ runs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.node-version }}
-    # - run: pnpm config set --location=project strictEngines true
-    #   if: ${{ inputs.strict-engines == 'true' }}
-    #   shell: bash
-    - run: pnpm install --config.strictEngines=true
+    - run: pnpm config set --location=project strictEngines true
       if: ${{ inputs.strict-engines == 'true' }}
       shell: bash
     - run: pnpm install --frozen-lockfile
       if: ${{ inputs.strict-engines == 'false' }}
+      shell: bash
+    - run: pnpm install
+      if: ${{ inputs.strict-engines == 'true' }}
       shell: bash
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,8 +4,12 @@ description: Sets up the repo for a typical CI job
 
 inputs:
   node-version:
-    description: "Node.js version to use"
+    description: Node.js version to use
     default: "lts/*"
+    required: false
+  strict-peers:
+    description: Whether to use strict peer dependency resolution
+    default: false
     required: false
 
 runs:
@@ -15,6 +19,8 @@ runs:
       with:
         cache: pnpm
         node-version: ${{ inputs.node-version }}
+    - run: pnpm config set strictPeerDependencies true
+      if: ${{ inputs.strict-peers == 'true' }}
     - run: pnpm install --frozen-lockfile
       shell: bash
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -19,7 +19,7 @@ runs:
       with:
         cache: pnpm
         node-version: ${{ inputs.node-version }}
-    - run: pnpm config set strictPeerDependencies true
+    - run: pnpm config set --location=project strictPeerDependencies true
       if: ${{ inputs.strict-peers == 'true' }}
       shell: bash
     - run: pnpm install --frozen-lockfile

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,6 +1,6 @@
-description: Prepares the repo for a typical CI job
+name: Setup
 
-name: Prepare
+description: Sets up the repo for a typical CI job
 
 inputs:
   node-version:

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -18,9 +18,6 @@ runs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.node-version }}
-    - run: pnpm config set --location=project strictPeerDependencies true
-      if: ${{ inputs.strict-peers == 'true' }}
-      shell: bash
-    - run: pnpm install --frozen-lockfile
+    - run: pnpm install --frozen-lockfile --strict-peer-dependencies=${{ inputs.strict-peers }}
       shell: bash
   using: composite

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,10 +7,6 @@ inputs:
     description: Node.js version to use
     default: "lts/*"
     required: false
-  strict-engines:
-    description: Whether to use strict engine compatibility checks
-    default: false
-    required: false
 
 runs:
   steps:
@@ -18,13 +14,6 @@ runs:
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: ${{ inputs.node-version }}
-    - run: pnpm config set --location=project strictEngines true
-      if: ${{ inputs.strict-engines == 'true' }}
-      shell: bash
     - run: pnpm install --frozen-lockfile
-      if: ${{ inputs.strict-engines == 'false' }}
-      shell: bash
-    - run: pnpm install
-      if: ${{ inputs.strict-engines == 'true' }}
       shell: bash
   using: composite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - run: pnpm dedupe --check --prefer-offline
 
   engines_check:
-    name: Verify Engines Compatibility
+    name: Engines Compatibility (Node.js ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           cache: pnpm
-          node-version: ${{ inputs.node-version }}
+          node-version: ${{ matrix.node-version }}
       - run: pnpm install --prod --engine-strict --ignore-scripts
 
   format_check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,9 @@ jobs:
           - 9
           - 10
         node-version:
+          - 22.13.0
           - 22
+          - 24.0.0
           - 24
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -85,14 +87,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        eslint-version:
-          - 9
-          - 10
-        node-version:
-          - 22.13.0
-          - 22
-          - 24.0.0
-          - 24
         os:
           - macos-latest
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm build
       - run: node lib/index.mjs
 
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm dedupe --check --prefer-offline
 
   format_check:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm format --list-different
 
   lint:
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm site:sync
       - run: pnpm lint
 
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm docs:generate --check
 
   lint_knip:
@@ -56,12 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm lint:knip
 
-  test:
-    name: Test (Node.js ${{ matrix.node-version }}, ESLint ${{ matrix.eslint-version }}, ${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+  test_node:
+    name: Test (Node.js ${{ matrix.node-version }}, ESLint ${{ matrix.eslint-version }})
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -71,18 +71,38 @@ jobs:
         node-version:
           - 22
           - 24
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: pnpm install -D eslint@${{ matrix.eslint-version }}
+      - run: pnpm test run
+
+  test_os:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        eslint-version:
+          - 9
+          - 10
+        node-version:
+          - 22.13.0
+          - 22
+          - 24.0.0
+          - 24
         os:
+          - macos-latest
           - ubuntu-latest
           - windows-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: pnpm install -D eslint@${{ matrix.eslint-version }}
+      - uses: ./.github/actions/setup
       - run: pnpm run test --coverage
       - uses: codecov/codecov-action@v5
-        if: always()
+        if: success() && (matrix.os == 'ubuntu-latest')
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -97,7 +117,7 @@ jobs:
           - 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm install -D eslint@${{ matrix.eslint-version }}
       - run: pnpm typecheck
 
@@ -106,5 +126,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
       - run: pnpm site:typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,26 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm dedupe --check --prefer-offline
 
+  engines_check:
+    name: Verify Engines Compatibility
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 20.19.0
+          - 20
+          - 22.12.0
+          - 22
+          - 24.0.0
+          - 24
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
+          strict-peers: true
+
   format_check:
     name: Format Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,26 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm dedupe --check --prefer-offline
 
+  engines_check:
+    name: Engines Check (Node.js ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version:
+          - 22.13.0
+          - 22
+          - 24.0.0
+          - 24
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          cache: pnpm
+          node-version: ${{ inputs.node-version }}
+      - run: pnpm install --prod --engine-strict --ignore-scripts
+
   format_check:
     name: Format Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 20.19.0
-          - 20
-          - 22.12.0
+          - 22.13.0
           - 22
           - 24.0.0
           - 24

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node-version }}
-          strict-peers: true
+          strict-engines: true
 
   format_check:
     name: Format Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,24 +26,6 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm dedupe --check --prefer-offline
 
-  engines_check:
-    name: Engines Compatibility (Node.js ${{ matrix.node-version }})
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version:
-          - 22.13.0
-          - 22
-          - 24.0.0
-          - 24
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-      - uses: ./.github/actions/setup
-        with:
-          node-version: ${{ matrix.node-version }}
-          strict-engines: true
-
   format_check:
     name: Format Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 22.13.0
+          - 22.22.2
           - 22
-          - 24.0.0
+          - 24.15.0
           - 24
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -89,9 +89,9 @@ jobs:
           - 9
           - 10
         node-version:
-          - 22.13.0
+          - 22.22.2
           - 22
-          - 24.0.0
+          - 24.15.0
           - 24
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
-      - uses: ./.github/actions/prepare
+      - uses: ./.github/actions/setup
 
       - name: Determine dist-tag
         id: determine_dist_tag

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,4 +4,5 @@ allowBuilds:
 minimumReleaseAge: 1440
 patchedDependencies:
   eslint-doc-generator: patches/eslint-doc-generator.patch
+strictEngines: true
 trustPolicy: no-downgrade

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,8 @@
 allowBuilds:
   esbuild: true
   sharp: true
+engineStrict: true
 minimumReleaseAge: 1440
 patchedDependencies:
   eslint-doc-generator: patches/eslint-doc-generator.patch
-strictEngines: true
 trustPolicy: no-downgrade

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,6 @@
 allowBuilds:
   esbuild: true
   sharp: true
-engineStrict: true
 minimumReleaseAge: 1440
 patchedDependencies:
   eslint-doc-generator: patches/eslint-doc-generator.patch


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1820
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds both minimum and latest versions of each major version we support to our test matrix, to ensure we're covering all of our bases.  It also breaks out the os tests to their own step, so there's fewer overall runs.  I've also added an "Engines Compatability" check.