### PR TITLE
fix: improve report range for `require-` rules

### DIFF
--- a/src/rules/require-attribution.ts
+++ b/src/rules/require-attribution.ts
@@ -44,7 +44,7 @@ export const rule = createRule({
           isPrivatePackage = true;
         }
       },
-      "Program:exit"(node) {
+      "Program:exit"() {
         if (ignorePrivate && isPrivatePackage) {
           return;
         }
@@ -67,15 +67,15 @@ export const rule = createRule({
           }
           if (!contributorsPropertyNode) {
             context.report({
+              loc: { column: 0, line: 1 },
               messageId: "missingContributor",
-              node,
             });
           }
         } else {
           if (!authorPropertyNode && !contributorsPropertyNode) {
             context.report({
+              loc: { column: 0, line: 1 },
               messageId: "missing",
-              node,
             });
           }
         }

--- a/src/tests/rules/require-attribution.test.ts
+++ b/src/tests/rules/require-attribution.test.ts
@@ -7,6 +7,8 @@ ruleTester.run("require-attribution", rule, {
       code: "{}",
       errors: [
         {
+          column: 1,
+          endColumn: undefined,
           line: 1,
           messageId: "missing",
         },
@@ -17,6 +19,8 @@ ruleTester.run("require-attribution", rule, {
       code: "{}",
       errors: [
         {
+          column: 1,
+          endColumn: undefined,
           line: 1,
           messageId: "missingContributor",
         },
@@ -92,6 +96,8 @@ ruleTester.run("require-attribution", rule, {
 }`,
       errors: [
         {
+          column: 1,
+          endColumn: undefined,
           line: 1,
           messageId: "missing",
         },

--- a/src/tests/rules/require-properties.test.ts
+++ b/src/tests/rules/require-properties.test.ts
@@ -22,7 +22,9 @@ for (const ruleName of ruleNames) {
         code: "{}",
         errors: [
           {
+            column: 1,
             data: { property: propertyName },
+            endColumn: undefined,
             line: 1,
             messageId: "missing",
           },
@@ -39,7 +41,9 @@ for (const ruleName of ruleNames) {
 }`,
         errors: [
           {
+            column: 1,
             data: { property: propertyName },
+            endColumn: undefined,
             line: 1,
             messageId: "missing",
           },
@@ -61,7 +65,9 @@ for (const ruleName of ruleNames) {
 }`,
         errors: [
           {
+            column: 1,
             data: { property: propertyName },
+            endColumn: undefined,
             line: 1,
             messageId: "missing",
           },
@@ -85,7 +91,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -107,7 +115,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -129,7 +139,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -147,7 +159,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -165,7 +179,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -181,7 +197,9 @@ for (const ruleName of ruleNames) {
               code: `{}`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -198,7 +216,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -221,7 +241,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -242,7 +264,9 @@ for (const ruleName of ruleNames) {
               code: `{}`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -264,7 +288,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -287,7 +313,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },
@@ -310,7 +338,9 @@ for (const ruleName of ruleNames) {
 }`,
               errors: [
                 {
+                  column: 1,
                   data: { property: propertyName },
+                  endColumn: undefined,
                   line: 1,
                   messageId: "missing",
                 },

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -87,8 +87,8 @@ export const createSimpleRequirePropertyRule = (
                         ? fixer.insertTextAfterRange([0, 1], ",")
                         : fixer.insertTextAfterRange([0, 1], "\n");
                     },
+              loc: { column: 0, line: 1 },
               messageId: "missing",
-              node: context.sourceCode.ast,
             });
           }
         },


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1838
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates the range that all `require-` rules report on, to just be the opening bracket of the file, rather than the entire file.

| Before | After |
|--|--|
| <img width="217" height="219" alt="screenshot-before" src="https://github.com/user-attachments/assets/be038a85-97ef-4c2b-82f8-0df28991814a" /> | <img width="64" height="75" alt="screenshot-after" src="https://github.com/user-attachments/assets/b8017370-2210-4633-94bd-144adacc3780" /> |
