### PR TITLE
docs: automatically populate Requirements note on Getting Started

### DIFF
--- a/site/src/components/Requirements.astro
+++ b/site/src/components/Requirements.astro
@@ -1,0 +1,20 @@
+---
+import { Aside } from "@astrojs/starlight/components";
+
+import packageJson from "../../../package.json" with { type: "json" };
+
+const engines = packageJson.engines;
+const nodeRange = engines.node;
+
+const peerDependencies = packageJson.peerDependencies;
+const eslintRange = peerDependencies.eslint;
+
+---
+
+<Aside type="note" title="Requirements">
+  <ul>
+    <li>ESLint: <code>{eslintRange}</code></li>
+    <li>Node: <code>{nodeRange}</code></li>
+  </ul>
+
+</Aside>

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -5,6 +5,8 @@ description: Install and configure the plugin.
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
+import Requirements from "~/components/Requirements.astro";
+
 ## 💽 Installation
 
 {/* prettier-ignore-start */}
@@ -34,11 +36,7 @@ import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 </Tabs>
 {/* prettier-ignore-end */}
 
-<Aside type="note" title="Requirements">
-- ESLint v9 or above
-- Node ^22.22.2 || >=24.15.0
-
-</Aside>
+<Requirements />
 
 ## 📖 Configs
 


### PR DESCRIPTION
This change introduces a `Requirements` component, that pulls engines and peerDependency information from the `package.json`, in order to populate the semver ranges for ESLint and Node.

<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1829
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview


| Before | After |
|--|--|
| <img width="293" height="309" alt="before" src="https://github.com/user-attachments/assets/a956afe1-d219-4ac7-8467-7b36a8ccfe2e" /> | <img width="312" height="280" alt="after" src="https://github.com/user-attachments/assets/de10bb3b-2135-46b9-bfdb-466b361f0645" /> |
