### PR TITLE
docs: remove extra </> from README.md after logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
   alt="Logo Image"
   height="240"
 />
-</>
 
 <h1 align="center">ESLint Plugin: Package JSON</h1>
 


### PR DESCRIPTION
quick lil docs fix, noticed this on https://www.npmjs.com/package/eslint-plugin-package-json:

<img width="813" height="597" alt="screenshot of the top of https://www.npmjs.com/package/eslint-plugin-package-json showing a > after the logo image" src="https://github.com/user-attachments/assets/f42f9ee9-be7e-40d5-adad-de88a0a05716" />
