### PR TITLE
docs: add missing (require|valid)-properties/ links to .md docs

### DIFF
--- a/docs/rules/require-attribution.md
+++ b/docs/rules/require-attribution.md
@@ -1,4 +1,4 @@
 # require-attribution
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-attribution>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-attribution>

--- a/docs/rules/require-attribution.md
+++ b/docs/rules/require-attribution.md
@@ -1,4 +1,4 @@
 # require-attribution
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-attribution>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-attribution>

--- a/docs/rules/require-author.md
+++ b/docs/rules/require-author.md
@@ -1,4 +1,4 @@
 # require-author
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-author>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-author>

--- a/docs/rules/require-bin.md
+++ b/docs/rules/require-bin.md
@@ -1,4 +1,4 @@
 # require-bin
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-bin>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-bin>

--- a/docs/rules/require-bugs.md
+++ b/docs/rules/require-bugs.md
@@ -1,4 +1,4 @@
 # require-bugs
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-bugs>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-bugs>

--- a/docs/rules/require-bundleDependencies.md
+++ b/docs/rules/require-bundleDependencies.md
@@ -1,4 +1,4 @@
 # require-bundleDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-bundleDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-bundleDependencies>

--- a/docs/rules/require-contributors.md
+++ b/docs/rules/require-contributors.md
@@ -1,4 +1,4 @@
 # require-contributors
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-contributors>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-contributors>

--- a/docs/rules/require-cpu.md
+++ b/docs/rules/require-cpu.md
@@ -1,4 +1,4 @@
 # require-cpu
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-cpu>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-cpu>

--- a/docs/rules/require-dependencies.md
+++ b/docs/rules/require-dependencies.md
@@ -1,4 +1,4 @@
 # require-dependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-dependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-dependencies>

--- a/docs/rules/require-description.md
+++ b/docs/rules/require-description.md
@@ -1,4 +1,4 @@
 # require-description
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-description>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-description>

--- a/docs/rules/require-devDependencies.md
+++ b/docs/rules/require-devDependencies.md
@@ -1,4 +1,4 @@
 # require-devDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-devDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-devDependencies>

--- a/docs/rules/require-devEngines.md
+++ b/docs/rules/require-devEngines.md
@@ -1,4 +1,4 @@
 # require-devEngines
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-devEngines>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-devEngines>

--- a/docs/rules/require-directories.md
+++ b/docs/rules/require-directories.md
@@ -1,4 +1,4 @@
 # require-directories
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-directories>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-directories>

--- a/docs/rules/require-engines.md
+++ b/docs/rules/require-engines.md
@@ -1,4 +1,4 @@
 # require-engines
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-engines>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-engines>

--- a/docs/rules/require-exports.md
+++ b/docs/rules/require-exports.md
@@ -1,4 +1,4 @@
 # require-exports
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-exports>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-exports>

--- a/docs/rules/require-files.md
+++ b/docs/rules/require-files.md
@@ -1,4 +1,4 @@
 # require-files
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-files>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-files>

--- a/docs/rules/require-funding.md
+++ b/docs/rules/require-funding.md
@@ -1,4 +1,4 @@
 # require-funding
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-funding>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-funding>

--- a/docs/rules/require-homepage.md
+++ b/docs/rules/require-homepage.md
@@ -1,4 +1,4 @@
 # require-homepage
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-homepage>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-homepage>

--- a/docs/rules/require-keywords.md
+++ b/docs/rules/require-keywords.md
@@ -1,4 +1,4 @@
 # require-keywords
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-keywords>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-keywords>

--- a/docs/rules/require-license.md
+++ b/docs/rules/require-license.md
@@ -1,4 +1,4 @@
 # require-license
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-license>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-license>

--- a/docs/rules/require-main.md
+++ b/docs/rules/require-main.md
@@ -1,4 +1,4 @@
 # require-main
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-main>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-main>

--- a/docs/rules/require-man.md
+++ b/docs/rules/require-man.md
@@ -1,4 +1,4 @@
 # require-man
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-man>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-man>

--- a/docs/rules/require-module.md
+++ b/docs/rules/require-module.md
@@ -1,4 +1,4 @@
 # require-module
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-module>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-module>

--- a/docs/rules/require-name.md
+++ b/docs/rules/require-name.md
@@ -1,4 +1,4 @@
 # require-name
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-name>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-name>

--- a/docs/rules/require-optionalDependencies.md
+++ b/docs/rules/require-optionalDependencies.md
@@ -1,4 +1,4 @@
 # require-optionalDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-optionalDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-optionalDependencies>

--- a/docs/rules/require-os.md
+++ b/docs/rules/require-os.md
@@ -1,4 +1,4 @@
 # require-os
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-os>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-os>

--- a/docs/rules/require-packageManager.md
+++ b/docs/rules/require-packageManager.md
@@ -1,4 +1,4 @@
 # require-packageManager
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-packageManager>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-packageManager>

--- a/docs/rules/require-peerDependencies.md
+++ b/docs/rules/require-peerDependencies.md
@@ -1,4 +1,4 @@
 # require-peerDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-peerDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-peerDependencies>

--- a/docs/rules/require-private.md
+++ b/docs/rules/require-private.md
@@ -1,4 +1,4 @@
 # require-private
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-private>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-private>

--- a/docs/rules/require-publishConfig.md
+++ b/docs/rules/require-publishConfig.md
@@ -1,4 +1,4 @@
 # require-publishConfig
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-publishConfig>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-publishConfig>

--- a/docs/rules/require-repository.md
+++ b/docs/rules/require-repository.md
@@ -1,4 +1,4 @@
 # require-repository
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-repository>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-repository>

--- a/docs/rules/require-scripts.md
+++ b/docs/rules/require-scripts.md
@@ -1,4 +1,4 @@
 # require-scripts
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-scripts>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-scripts>

--- a/docs/rules/require-sideEffects.md
+++ b/docs/rules/require-sideEffects.md
@@ -1,4 +1,4 @@
 # require-sideEffects
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-sideEffects>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-sideEffects>

--- a/docs/rules/require-type.md
+++ b/docs/rules/require-type.md
@@ -1,4 +1,4 @@
 # require-type
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-type>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-type>

--- a/docs/rules/require-types.md
+++ b/docs/rules/require-types.md
@@ -1,4 +1,4 @@
 # require-types
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-types>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-types>

--- a/docs/rules/require-version.md
+++ b/docs/rules/require-version.md
@@ -1,4 +1,4 @@
 # require-version
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-version>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/require-properties/require-version>

--- a/docs/rules/valid-author.md
+++ b/docs/rules/valid-author.md
@@ -1,4 +1,4 @@
 # valid-author
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-author>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-author>

--- a/docs/rules/valid-bin.md
+++ b/docs/rules/valid-bin.md
@@ -1,4 +1,4 @@
 # valid-bin
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-bin>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bin>

--- a/docs/rules/valid-bugs.md
+++ b/docs/rules/valid-bugs.md
@@ -1,4 +1,4 @@
 # valid-bugs
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-bugs>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bugs>

--- a/docs/rules/valid-bundleDependencies.md
+++ b/docs/rules/valid-bundleDependencies.md
@@ -1,4 +1,4 @@
 # valid-bundleDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-bundleDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bundleDependencies>

--- a/docs/rules/valid-config.md
+++ b/docs/rules/valid-config.md
@@ -1,4 +1,4 @@
 # valid-config
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-config>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-config>

--- a/docs/rules/valid-contributors.md
+++ b/docs/rules/valid-contributors.md
@@ -1,4 +1,4 @@
 # valid-contributors
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-contributors>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-contributors>

--- a/docs/rules/valid-cpu.md
+++ b/docs/rules/valid-cpu.md
@@ -1,4 +1,4 @@
 # valid-cpu
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-cpu>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-cpu>

--- a/docs/rules/valid-dependencies.md
+++ b/docs/rules/valid-dependencies.md
@@ -1,4 +1,4 @@
 # valid-dependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-dependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-dependencies>

--- a/docs/rules/valid-description.md
+++ b/docs/rules/valid-description.md
@@ -1,4 +1,4 @@
 # valid-description
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-description>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-description>

--- a/docs/rules/valid-devDependencies.md
+++ b/docs/rules/valid-devDependencies.md
@@ -1,4 +1,4 @@
 # valid-devDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-devDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-devDependencies>

--- a/docs/rules/valid-devEngines.md
+++ b/docs/rules/valid-devEngines.md
@@ -1,4 +1,4 @@
 # valid-devEngines
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-devEngines>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-devEngines>

--- a/docs/rules/valid-directories.md
+++ b/docs/rules/valid-directories.md
@@ -1,4 +1,4 @@
 # valid-directories
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-directories>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-directories>

--- a/docs/rules/valid-engines.md
+++ b/docs/rules/valid-engines.md
@@ -1,4 +1,4 @@
 # valid-engines
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-engines>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-engines>

--- a/docs/rules/valid-exports.md
+++ b/docs/rules/valid-exports.md
@@ -1,4 +1,4 @@
 # valid-exports
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-exports>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-exports>

--- a/docs/rules/valid-files.md
+++ b/docs/rules/valid-files.md
@@ -1,4 +1,4 @@
 # valid-files
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-files>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-files>

--- a/docs/rules/valid-funding.md
+++ b/docs/rules/valid-funding.md
@@ -1,4 +1,4 @@
 # valid-funding
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-funding>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-funding>

--- a/docs/rules/valid-homepage.md
+++ b/docs/rules/valid-homepage.md
@@ -1,4 +1,4 @@
 # valid-homepage
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-homepage>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-homepage>

--- a/docs/rules/valid-keywords.md
+++ b/docs/rules/valid-keywords.md
@@ -1,4 +1,4 @@
 # valid-keywords
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-keywords>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-keywords>

--- a/docs/rules/valid-license.md
+++ b/docs/rules/valid-license.md
@@ -1,4 +1,4 @@
 # valid-license
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-license>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-license>

--- a/docs/rules/valid-main.md
+++ b/docs/rules/valid-main.md
@@ -1,4 +1,4 @@
 # valid-main
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-main>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-main>

--- a/docs/rules/valid-man.md
+++ b/docs/rules/valid-man.md
@@ -1,4 +1,4 @@
 # valid-man
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-man>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-man>

--- a/docs/rules/valid-module.md
+++ b/docs/rules/valid-module.md
@@ -1,4 +1,4 @@
 # valid-module
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-module>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-module>

--- a/docs/rules/valid-name.md
+++ b/docs/rules/valid-name.md
@@ -1,4 +1,4 @@
 # valid-name
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-name>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-name>

--- a/docs/rules/valid-optionalDependencies.md
+++ b/docs/rules/valid-optionalDependencies.md
@@ -1,4 +1,4 @@
 # valid-optionalDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-optionalDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-optionalDependencies>

--- a/docs/rules/valid-os.md
+++ b/docs/rules/valid-os.md
@@ -1,4 +1,4 @@
 # valid-os
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-os>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-os>

--- a/docs/rules/valid-packageManager.md
+++ b/docs/rules/valid-packageManager.md
@@ -1,4 +1,4 @@
 # valid-packageManager
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-packageManager>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-packageManager>

--- a/docs/rules/valid-peerDependencies.md
+++ b/docs/rules/valid-peerDependencies.md
@@ -1,4 +1,4 @@
 # valid-peerDependencies
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-peerDependencies>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-peerDependencies>

--- a/docs/rules/valid-private.md
+++ b/docs/rules/valid-private.md
@@ -1,4 +1,4 @@
 # valid-private
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-private>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-private>

--- a/docs/rules/valid-publishConfig.md
+++ b/docs/rules/valid-publishConfig.md
@@ -1,4 +1,4 @@
 # valid-publishConfig
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-publishConfig>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-publishConfig>

--- a/docs/rules/valid-repository-directory.md
+++ b/docs/rules/valid-repository-directory.md
@@ -1,4 +1,4 @@
 # valid-repository-directory
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-repository-directory>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-repository-directory>

--- a/docs/rules/valid-repository-directory.md
+++ b/docs/rules/valid-repository-directory.md
@@ -1,4 +1,4 @@
 # valid-repository-directory
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-repository-directory>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-repository-directory>

--- a/docs/rules/valid-repository.md
+++ b/docs/rules/valid-repository.md
@@ -1,4 +1,4 @@
 # valid-repository
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-repository>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-repository>

--- a/docs/rules/valid-scripts.md
+++ b/docs/rules/valid-scripts.md
@@ -1,4 +1,4 @@
 # valid-scripts
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-scripts>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-scripts>

--- a/docs/rules/valid-sideEffects.md
+++ b/docs/rules/valid-sideEffects.md
@@ -1,4 +1,4 @@
 # valid-sideEffects
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-sideEffects>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-sideEffects>

--- a/docs/rules/valid-type.md
+++ b/docs/rules/valid-type.md
@@ -1,4 +1,4 @@
 # valid-type
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-type>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-type>

--- a/docs/rules/valid-version.md
+++ b/docs/rules/valid-version.md
@@ -1,4 +1,4 @@
 # valid-version
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-version>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-version>

--- a/docs/rules/valid-workspaces.md
+++ b/docs/rules/valid-workspaces.md
@@ -1,4 +1,4 @@
 # valid-workspaces
 
 > [!NOTE]
-> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-workspaces>
+> You can find the docs for this rule on our website: <https://eslint-plugin-package-json.dev/rules/valid-properties/valid-workspaces>


### PR DESCRIPTION
another quick lil docs fix I noticed we'd missed