### PR TITLE
feat(experimental): add new `/experimental` entry point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm build
       - run: node lib/index.mjs
+      - run: node lib/experimental/index.mjs
 
   dedupe_check:
     name: Dedupe Check

--- a/package.json
+++ b/package.json
@@ -33,6 +33,10 @@
     ".": {
       "types": "./lib/index.d.mts",
       "default": "./lib/index.mjs"
+    },
+    "./experimental": {
+      "types": "./lib/experimental/index.d.mts",
+      "default": "./lib/experimental/index.mjs"
     }
   },
   "main": "lib/index.mjs",

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -51,7 +51,10 @@ import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
   // your other ESLint configurations
-  packageJson.configs.recommended,
+  {
+    extends: [packageJson.configs.recommended],
+    files: ['package.json'],
+  },
 ]);
 ```
 
@@ -97,7 +100,10 @@ import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
   // your other ESLint configurations
-  packageJson.configs['recommended-publishable'],
+  {
+    extends: [packageJson.configs['recommended-publishable']],
+    files: ['package.json'],
+  },
 ]);
 ```
 
@@ -113,8 +119,10 @@ import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
   // your other ESLint configurations
-  packageJson.configs.recommended, // or packageJson.configs["recommended-publishable"]
-  packageJson.configs.stylistic,
+  {
+    extends: [packageJson.configs.recommended, packageJson.configs.stylistic],
+    files: ['package.json'],
+  },
 ]);
 ```
 
@@ -163,3 +171,28 @@ By default, this is:
 By specifying this setting as `true` or `false`, it will override the defaults and apply the setting for ALL rules.
 In that case, either all `require-*` rules will be applied to private packages or no `require-*` rules will be applied to private packages.
 Even then, you can override the setting again at the rule level, by using the rule's `ignorePrivate` option, which will take precedence over this global setting.
+
+## 🧪 Experimental Plugin
+
+In addition to the plugin provided in the primary entry point, this package also exports an experimental version of the plugin.
+We intend to use the experimental API to provide a version of the plugin that will work with the `json` language from `@eslint/json` (instead of the parser from `jsonc-eslint-parser`).
+For now, the experimental plugin is identical to the main plugin, but this will change as we implement the new version of the plugin.
+
+<Aside type="caution">
+  All exports from the `/experimental` entry point are considered unstable and
+  may change in breaking ways in minor version releases.
+</Aside>
+
+```ts
+// eslint.config.ts
+import packageJson from 'eslint-plugin-package-json/experimental';
+import { defineConfig } from 'eslint/config';
+
+export default defineConfig([
+  // your other ESLint configurations
+  {
+    extends: [packageJson.configs.recommended],
+    files: ['package.json'],
+  },
+]);
+```

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -172,7 +172,7 @@ By specifying this setting as `true` or `false`, it will override the defaults a
 In that case, either all `require-*` rules will be applied to private packages or no `require-*` rules will be applied to private packages.
 Even then, you can override the setting again at the rule level, by using the rule's `ignorePrivate` option, which will take precedence over this global setting.
 
-## 🧪 Experimental Plugin
+## 🧪 Experimental API
 
 In addition to the plugin provided in the primary entry point, this package also exports an experimental version of the plugin.
 We intend to use the experimental API to provide a version of the plugin that will work with the `json` language from `@eslint/json` (instead of the parser from `jsonc-eslint-parser`).
@@ -196,3 +196,8 @@ export default defineConfig([
   },
 ]);
 ```
+
+<Aside>
+  You can learn more about our `@eslint/json` migration plan
+  [here](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/docs/plans/parser-to-language-migration/plan.md).
+</Aside>

--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -1,0 +1,8 @@
+import { plugin } from '../plugin.ts';
+
+export const rules = plugin.rules;
+export const configs = plugin.configs;
+
+export default plugin;
+
+export type { PackageJsonPluginSettings } from '../createRule.ts';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,4 @@ export const configs = plugin.configs;
 
 export default plugin;
 
-export type { PackageJsonPluginSettings } from './createRule.js';
+export type { PackageJsonPluginSettings } from './createRule.ts';


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1862
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new `/experimental` entry point, which we'll use to export a version of the plugin that will work with the `json` language from `@eslint/json` (instead of the parser from jsonc-eslint-parser).

Right now, the exports are the same as the primary entry point, but that will change as we progress in our [migration plan](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/docs/plans/parser-to-language-migration/plan.md#milestone-1-experimental-language-support).

<img width="780" height="810" alt="ui" src="https://github.com/user-attachments/assets/245f407a-25e2-489a-baa5-88e06aa45c85" />

