### PR TITLE
feat(experimental): add `meta.languages` to all rules

### DIFF
--- a/src/experimental/plugin.ts
+++ b/src/experimental/plugin.ts
@@ -11,6 +11,11 @@ const rules = Object.fromEntries(
   ]),
 );
 
+// Add `meta.languages` to enforce use of the json/json language.
+for (const rule of Object.values(rules)) {
+  rule.meta.languages ??= ['json/json'];
+}
+
 export const plugin = {
   configs: {
     recommended: {

--- a/src/experimental/plugin.ts
+++ b/src/experimental/plugin.ts
@@ -13,7 +13,8 @@ const rules = Object.fromEntries(
 
 // Add `meta.languages` to enforce use of the json/json language.
 for (const rule of Object.values(rules)) {
-  rule.meta.languages ??= ['json/json'];
+  // Manually add the `languages` property in the types, since ESLint v9 types doesn't include it (resulting in a type check error in CI).
+  (rule.meta as { languages?: string[] }).languages ??= ['json/json'];
 }
 
 export const plugin = {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1885
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds `meta.languages` to all of the language-compatible rules to enforce the contract with `@eslint/json`.
