### PR TITLE
chore: move import sorting to prettier

### DIFF
--- a/e2e/experimental-configs/eslint.config.js
+++ b/e2e/experimental-configs/eslint.config.js
@@ -1,6 +1,6 @@
+import jsonPlugin from '@eslint/json';
 import packageJson from 'eslint-plugin-package-json/experimental';
 import { defineConfig } from 'eslint/config';
-import jsonPlugin from '@eslint/json';
 
 export default defineConfig([
   {

--- a/e2e/experimental-rules/eslint.config.js
+++ b/e2e/experimental-rules/eslint.config.js
@@ -1,6 +1,6 @@
+import jsonPlugin from '@eslint/json';
 import packageJson from 'eslint-plugin-package-json/experimental';
 import { defineConfig } from 'eslint/config';
-import jsonPlugin from '@eslint/json';
 
 export default defineConfig([
   {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -62,8 +62,10 @@ export default defineConfig(
           type: 'natural',
         },
       ],
+
       // Covered by Prettier
       'perfectionist/sort-imports': 'off',
+      'perfectionist/sort-named-imports': 'off',
 
       // Stylistic concerns that don't interfere with Prettier
       'logical-assignment-operators': [

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -62,6 +62,9 @@ export default defineConfig(
           type: 'natural',
         },
       ],
+      // Covered by Prettier
+      'perfectionist/sort-imports': 'off',
+
       // Stylistic concerns that don't interfere with Prettier
       'logical-assignment-operators': [
         'error',

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@eslint/js": "10.0.1",
     "@eslint/json": "1.2.0",
     "@eslint/markdown": "8.0.1",
+    "@ianvs/prettier-plugin-sort-imports": "^4.7.1",
     "@types/estree": "1.0.8",
     "@types/node": "24.12.0",
     "@types/semver": "7.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@eslint/markdown':
         specifier: 8.0.1
         version: 8.0.1
+      '@ianvs/prettier-plugin-sort-imports':
+        specifier: ^4.7.1
+        version: 4.7.1(prettier@3.8.0)
       '@types/estree':
         specifier: 1.0.8
         version: 1.0.8
@@ -212,12 +215,28 @@ packages:
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/generator@8.0.0-rc.5':
     resolution: {integrity: sha512-nFZPWz3FHIS7y6rMIVoa/WBwjdutfIaRJIBQjzn+t3RnecZoRNlGmGcyR2wb0T/IgSd50Kz/6dG8/LvMCRunjg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@8.0.0-rc.5':
@@ -228,12 +247,21 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@8.0.0-rc.5':
     resolution: {integrity: sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/parser@7.29.3':
     resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -251,8 +279,20 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@8.0.0-rc.5':
@@ -550,6 +590,24 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@ianvs/prettier-plugin-sort-imports@4.7.1':
+    resolution: {integrity: sha512-jmTNYGlg95tlsoG3JLCcuC4BrFELJtLirLAkQW/71lXSyOhVt/Xj7xWbbGcuVbNq1gwWgSyMrPjJc9Z30hynVw==}
+    peerDependencies:
+      '@prettier/plugin-oxc': ^0.0.4 || ^0.1.0
+      '@vue/compiler-sfc': 2.7.x || 3.x
+      content-tag: ^4.0.0
+      prettier: 2 || 3 || ^4.0.0-0
+      prettier-plugin-ember-template-tag: ^2.1.0
+    peerDependenciesMeta:
+      '@prettier/plugin-oxc':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      content-tag:
+        optional: true
+      prettier-plugin-ember-template-tag:
+        optional: true
 
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
@@ -3895,6 +3953,20 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
   '@babel/generator@8.0.0-rc.5':
     dependencies:
       '@babel/parser': 8.0.0-rc.5
@@ -3904,17 +3976,27 @@ snapshots:
       '@types/jsesc': 2.5.1
       jsesc: 3.1.0
 
+  '@babel/helper-globals@7.29.7': {}
+
   '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-string-parser@8.0.0-rc.5': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.5': {}
 
   '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/parser@8.0.0-rc.4':
     dependencies:
@@ -3926,10 +4008,33 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/types@7.29.0':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@8.0.0-rc.5':
     dependencies:
@@ -4175,6 +4280,17 @@ snapshots:
   '@humanwhocodes/momoa@3.3.10': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.0)':
+    dependencies:
+      '@babel/generator': 7.29.7
+      '@babel/parser': 7.29.3
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.0
+      prettier: 3.8.0
+      semver: 7.8.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@img/colour@1.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,10 +211,6 @@ packages:
     resolution: {integrity: sha512-j8DNruA8ors99Al39RYZPJK4DC1bKkoNm93mAMuBhY9TCNC4R8n1q7ovFnJ5qhGh5Lsh7pa1gpQVpYpsJPeTHQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
-  '@babel/code-frame@7.29.0':
-    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
@@ -231,10 +227,6 @@ packages:
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
@@ -243,10 +235,6 @@ packages:
     resolution: {integrity: sha512-sN7R8rBvDurfaziNfDEIjIntlazmlkCDGO4SNl2RJ3wRCn+QxspLV7hzYAE8WWVd2joVuT8sUxeePdLp2idI1A==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
@@ -254,11 +242,6 @@ packages:
   '@babel/helper-validator-identifier@8.0.0-rc.5':
     resolution: {integrity: sha512-ehJDxHvtbZ85RtX/L2fi0h9AGsBNqB5Euv1EB8RMAvGYvD+2X+QbpzzOpbklnNXO+WSZJNOaetw2BBj27xsWVg==}
     engines: {node: ^22.18.0 || >=24.11.0}
-
-  '@babel/parser@7.29.3':
-    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
 
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
@@ -285,10 +268,6 @@ packages:
 
   '@babel/traverse@7.29.7':
     resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.29.0':
-    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
@@ -3947,12 +3926,6 @@ snapshots:
       is-wsl: 3.1.1
       which-pm-runs: 1.1.0
 
-  '@babel/code-frame@7.29.0':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -3978,21 +3951,13 @@ snapshots:
 
   '@babel/helper-globals@7.29.7': {}
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
 
   '@babel/helper-string-parser@8.0.0-rc.5': {}
 
-  '@babel/helper-validator-identifier@7.28.5': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-identifier@8.0.0-rc.5': {}
-
-  '@babel/parser@7.29.3':
-    dependencies:
-      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -4025,11 +3990,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.29.0':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.7':
     dependencies:
@@ -4284,9 +4244,9 @@ snapshots:
   '@ianvs/prettier-plugin-sort-imports@4.7.1(prettier@3.8.0)':
     dependencies:
       '@babel/generator': 7.29.7
-      '@babel/parser': 7.29.3
+      '@babel/parser': 7.29.7
       '@babel/traverse': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       prettier: 3.8.0
       semver: 7.8.0
     transitivePeerDependencies:
@@ -5658,7 +5618,7 @@ snapshots:
 
   eslint-plugin-unicorn@64.0.0(eslint@10.4.0(jiti@2.7.0)):
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.0(jiti@2.7.0))
       change-case: 5.4.4
       ci-info: 4.4.0
@@ -6302,8 +6262,8 @@ snapshots:
 
   magicast@0.5.3:
     dependencies:
-      '@babel/parser': 7.29.3
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -7010,7 +6970,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.29.0
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,11 +3,14 @@
  * @type {import("prettier").Config}
  */
 const config = {
+  importOrder: ['<BUILTIN_MODULES>', '', '<THIRD_PARTY_MODULES>', '', '^[./]'],
+  importOrderTypeScriptVersion: '6.0.0',
   overrides: [{ files: '.nvmrc', options: { parser: 'yaml' } }],
   plugins: [
     'prettier-plugin-curly',
     'prettier-plugin-packagejson',
     'prettier-plugin-sh',
+    '@ianvs/prettier-plugin-sort-imports',
   ],
   singleQuote: true,
 };

--- a/site/src/content/docs/getting-started.mdx
+++ b/site/src/content/docs/getting-started.mdx
@@ -3,7 +3,7 @@ title: Getting Started
 description: Install and configure the plugin.
 ---
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 import Requirements from '~/components/Requirements.astro';
 
@@ -191,8 +191,8 @@ In a future major version, we plan to make this the default and only experience,
 ```ts
 // eslint.config.ts
 import jsonPlugin from '@eslint/json';
-import { defineConfig } from 'eslint/config';
 import packageJson from 'eslint-plugin-package-json/experimental';
+import { defineConfig } from 'eslint/config';
 
 export default defineConfig([
   // your other ESLint configurations

--- a/site/src/content/docs/rules/bin-name-casing.mdx
+++ b/site/src/content/docs/rules/bin-name-casing.mdx
@@ -9,7 +9,7 @@ description: 'Enforce that names for bin properties are in kebab case.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces that when your `bin` value is an object, its keys (representing the commands for each script) should be in [kebab case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (e.g. `my-command`).
 

--- a/site/src/content/docs/rules/exports-subpaths-style.mdx
+++ b/site/src/content/docs/rules/exports-subpaths-style.mdx
@@ -9,7 +9,7 @@ description: 'Enforce consistent format for the exports field (implicit or expli
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces consistent formatting for the `exports` property, ensuring either explicit sub-path notation with `"."` or implicit root-level exports.
 

--- a/site/src/content/docs/rules/no-empty-fields.mdx
+++ b/site/src/content/docs/rules/no-empty-fields.mdx
@@ -9,7 +9,7 @@ description: 'Reports on unnecessary empty arrays and objects.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule flags all empty Arrays and objects, as such empty expressions do nothing and are often the result of a mistake.
 It will report both named properties that are empty, as well as nested arrays and objects that are empty.

--- a/site/src/content/docs/rules/no-local-dependencies.mdx
+++ b/site/src/content/docs/rules/no-local-dependencies.mdx
@@ -5,7 +5,7 @@ description: 'Requires that dependencies do not use local file paths, which will
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces that no `dependencies` are declared with local file paths, since this will likely result in errors when installing from a registry.
 This includes any paths that start with `file:`, `link:`, `./`, or `../`.

--- a/site/src/content/docs/rules/no-redundant-files.mdx
+++ b/site/src/content/docs/rules/no-redundant-files.mdx
@@ -9,7 +9,7 @@ description: 'Prevents adding unnecessary / redundant files.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks that the `files` property doesn't contain any redundant or unnecessary file entries.
 By default, [npm will automatically](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files) include certain files, based on a number of circumstances.

--- a/site/src/content/docs/rules/no-redundant-publishConfig.mdx
+++ b/site/src/content/docs/rules/no-redundant-publishConfig.mdx
@@ -9,7 +9,7 @@ description: 'Warns when publishConfig.access is used in unscoped packages.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule warns when `publishConfig.access` is used in unscoped packages, as it has no effect.
 

--- a/site/src/content/docs/rules/order-properties.mdx
+++ b/site/src/content/docs/rules/order-properties.mdx
@@ -9,7 +9,7 @@ description: 'Package properties should be declared in standard order'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 A conventional order exists for `package.json` top-level properties.
 npm does not enforce this order, but for consistency and readability, this rule can enforce it.

--- a/site/src/content/docs/rules/repository-shorthand.mdx
+++ b/site/src/content/docs/rules/repository-shorthand.mdx
@@ -9,7 +9,7 @@ description: 'Enforce either object or shorthand declaration for repository.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces that the `repository` property uses either object _(default)_ or shorthand notation to refer to GitHub repositories.
 

--- a/site/src/content/docs/rules/require-attribution.mdx
+++ b/site/src/content/docs/rules/require-attribution.mdx
@@ -9,7 +9,7 @@ description: 'Ensures that proper attribution is included, requiring that either
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule ensures that proper attribution is included in a package, requiring that either `author` or `contributors` is defined.
 If `contributors` is present, it should include at least one contributor.

--- a/site/src/content/docs/rules/require-properties/require-author.mdx
+++ b/site/src/content/docs/rules/require-properties/require-author.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `author` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `author` property in a `package.json`, and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-bin.mdx
+++ b/site/src/content/docs/rules/require-properties/require-bin.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `bin` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `bin` property in a `package.json`, and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-browser.mdx
+++ b/site/src/content/docs/rules/require-properties/require-browser.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `browser` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `browser` property in a `package.json`, and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-bugs.mdx
+++ b/site/src/content/docs/rules/require-properties/require-bugs.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `bugs` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `bugs` property in a `package.json`, and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-bundleDependencies.mdx
+++ b/site/src/content/docs/rules/require-properties/require-bundleDependencies.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `bundleDependencies` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `bundleDependencies` property in a `package.json`, and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-config.mdx
+++ b/site/src/content/docs/rules/require-properties/require-config.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `config` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `config` property in a `package.json`, and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-contributors.mdx
+++ b/site/src/content/docs/rules/require-properties/require-contributors.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `contributors` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `contributors` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-cpu.mdx
+++ b/site/src/content/docs/rules/require-properties/require-cpu.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `cpu` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `cpu` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-dependencies.mdx
+++ b/site/src/content/docs/rules/require-properties/require-dependencies.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `dependencies` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `dependencies` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-description.mdx
+++ b/site/src/content/docs/rules/require-properties/require-description.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `description` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `description` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-devDependencies.mdx
+++ b/site/src/content/docs/rules/require-properties/require-devDependencies.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `devDependencies` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `devDependencies` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-devEngines.mdx
+++ b/site/src/content/docs/rules/require-properties/require-devEngines.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `devEngines` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `devEngines` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-directories.mdx
+++ b/site/src/content/docs/rules/require-properties/require-directories.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `directories` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `directories` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-engines.mdx
+++ b/site/src/content/docs/rules/require-properties/require-engines.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `engines` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `engines` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-exports.mdx
+++ b/site/src/content/docs/rules/require-properties/require-exports.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `exports` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `exports` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-files.mdx
+++ b/site/src/content/docs/rules/require-properties/require-files.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `files` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `files` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-funding.mdx
+++ b/site/src/content/docs/rules/require-properties/require-funding.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `funding` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `funding` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-gypfile.mdx
+++ b/site/src/content/docs/rules/require-properties/require-gypfile.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `gypfile` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `gypfile` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-homepage.mdx
+++ b/site/src/content/docs/rules/require-properties/require-homepage.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `homepage` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `homepage` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-keywords.mdx
+++ b/site/src/content/docs/rules/require-properties/require-keywords.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `keywords` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `keywords` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-libc.mdx
+++ b/site/src/content/docs/rules/require-properties/require-libc.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `libc` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `libc` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-license.mdx
+++ b/site/src/content/docs/rules/require-properties/require-license.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `license` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `license` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-main.mdx
+++ b/site/src/content/docs/rules/require-properties/require-main.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `main` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `main` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-man.mdx
+++ b/site/src/content/docs/rules/require-properties/require-man.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `man` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `man` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-module.mdx
+++ b/site/src/content/docs/rules/require-properties/require-module.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `module` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `module` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-name.mdx
+++ b/site/src/content/docs/rules/require-properties/require-name.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `name` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `name` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-optionalDependencies.mdx
+++ b/site/src/content/docs/rules/require-properties/require-optionalDependencies.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `optionalDependencies` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `optionalDependencies` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-os.mdx
+++ b/site/src/content/docs/rules/require-properties/require-os.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `os` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `os` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-packageManager.mdx
+++ b/site/src/content/docs/rules/require-properties/require-packageManager.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `packageManager` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `packageManager` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-peerDependencies.mdx
+++ b/site/src/content/docs/rules/require-properties/require-peerDependencies.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `peerDependencies` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `peerDependencies` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-peerDependenciesMeta.mdx
+++ b/site/src/content/docs/rules/require-properties/require-peerDependenciesMeta.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `peerDependenciesMeta` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `peerDependenciesMeta` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-private.mdx
+++ b/site/src/content/docs/rules/require-properties/require-private.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `private` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `private` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-publishConfig.mdx
+++ b/site/src/content/docs/rules/require-properties/require-publishConfig.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `publishConfig` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `publishConfig` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-repository.mdx
+++ b/site/src/content/docs/rules/require-properties/require-repository.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `repository` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `repository` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-scripts.mdx
+++ b/site/src/content/docs/rules/require-properties/require-scripts.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `scripts` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `scripts` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-sideEffects.mdx
+++ b/site/src/content/docs/rules/require-properties/require-sideEffects.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `sideEffects` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `sideEffects` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-type.mdx
+++ b/site/src/content/docs/rules/require-properties/require-type.mdx
@@ -9,7 +9,7 @@ description: 'Requires the `type` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `type` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-types.mdx
+++ b/site/src/content/docs/rules/require-properties/require-types.mdx
@@ -5,7 +5,7 @@ description: 'Requires the `types` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `types` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/require-properties/require-version.mdx
+++ b/site/src/content/docs/rules/require-properties/require-version.mdx
@@ -7,7 +7,7 @@ description: 'Requires the `version` property to be present.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks for the existence of the `version` property and reports a violation if it doesn't exist.
 

--- a/site/src/content/docs/rules/restrict-dependency-ranges.mdx
+++ b/site/src/content/docs/rules/restrict-dependency-ranges.mdx
@@ -7,7 +7,7 @@ description: 'Restricts the range of dependencies to allow or disallow specific 
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule allows you to require that specific dependencies use a particular kind of semver range (e.g. `^`).
 There are several options for specifying which dependencies a range type restriction should be applied to, including dependency type, package name (or name regex pattern), and version range (e.g. `'<1'`).

--- a/site/src/content/docs/rules/restrict-private-properties.mdx
+++ b/site/src/content/docs/rules/restrict-private-properties.mdx
@@ -7,7 +7,7 @@ description: 'Disallows unnecessary properties in private packages.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule disallows unnecessary properties in private packages that are never published to npm.
 

--- a/site/src/content/docs/rules/restrict-top-level-properties.mdx
+++ b/site/src/content/docs/rules/restrict-top-level-properties.mdx
@@ -7,7 +7,7 @@ description: 'Disallows specified top-level properties in package.json.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule allows you to disallow specific top-level properties.
 This is useful when you want to keep your`package.json` minimal and enforce that certain tool configurations live in their own dedicated files.

--- a/site/src/content/docs/rules/scripts-name-casing.mdx
+++ b/site/src/content/docs/rules/scripts-name-casing.mdx
@@ -9,7 +9,7 @@ description: 'Enforce that names for `scripts` are in kebab case (optionally sep
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces that the keys of the `scripts` object (representing the commands for each script) should be in [kebab case](https://developer.mozilla.org/en-US/docs/Glossary/Kebab_case) (e.g. `"my-script"`).
 It also permits kebab case segments separated by colons (e.g. `"test:my-script"`).

--- a/site/src/content/docs/rules/sort-collections.mdx
+++ b/site/src/content/docs/rules/sort-collections.mdx
@@ -9,7 +9,7 @@ description: 'Selected collections must be in a consistent order (lexicographica
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces that specified collections (e.g. `dependencies`, `scripts`, etc.) are sorted in a consistent order.
 

--- a/site/src/content/docs/rules/specify-peers-locally.mdx
+++ b/site/src/content/docs/rules/specify-peers-locally.mdx
@@ -9,7 +9,7 @@ description: 'Requires that all peer dependencies are also declared as dev depen
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule requires that all peer dependencies are also declared as dev dependencies.
 

--- a/site/src/content/docs/rules/unique-dependencies.mdx
+++ b/site/src/content/docs/rules/unique-dependencies.mdx
@@ -9,7 +9,7 @@ description: "Checks a dependency isn't specified more than once (i.e. in `depen
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks that every dependency is just added once to a `package.json` key specifying dependencies (e.g. `dependencies`, `devDependencies`, `peerDependencies`, `optionalDependencies`).
 It also checks that any dependencies declared in the `dependencies` group, are not also present in `peerDependencies` or `devDependencies`.

--- a/site/src/content/docs/rules/valid-peerDependenciesMeta-relationship.mdx
+++ b/site/src/content/docs/rules/valid-peerDependenciesMeta-relationship.mdx
@@ -9,7 +9,7 @@ description: "Enforces that any dependencies declared in `peerDependenciesMeta` 
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces that every dependency declared inside `peerDependenciesMeta` is also declared in `peerDependencies`.
 

--- a/site/src/content/docs/rules/valid-properties/valid-author.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-author.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `author` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `author` property in `package.json` files against the npm specification.
 The field can be either a string or an object with `name` and optionally `email` or `url` properties.

--- a/site/src/content/docs/rules/valid-properties/valid-bin.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-bin.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `bin` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `bin` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-browser.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-browser.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `browser` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks that the `browser` property is a non-empty string.
 

--- a/site/src/content/docs/rules/valid-properties/valid-bugs.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-bugs.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `bugs` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `bugs` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-bundleDependencies.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-bundleDependencies.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `bundleDependencies` (also `bundledDependencies`)
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `bundleDependencies` property (as well as its alias `bundledDependencies`) in a `package.json` against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-config.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-config.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `config` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 The rule checks that, if present, the `config` property is an object.
 

--- a/site/src/content/docs/rules/valid-properties/valid-contributors.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-contributors.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `contributors` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `contributors` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-cpu.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-cpu.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `cpu` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 The rule checks that, if present, the `cpu` property is an Array of non-empty strings.
 

--- a/site/src/content/docs/rules/valid-properties/valid-dependencies.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-dependencies.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `dependencies` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `dependencies` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-description.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-description.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `description` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 The rule checks that, if present, the `description` property is a non-empty string.
 

--- a/site/src/content/docs/rules/valid-properties/valid-devDependencies.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-devDependencies.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `devDependencies` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `devDependencies` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-devEngines.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-devEngines.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `devEngines` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `devEngines` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-directories.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-directories.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `directories` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 The rule checks that, if present, the `directories` property is an object.
 

--- a/site/src/content/docs/rules/valid-properties/valid-engines.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-engines.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `engines` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `engines` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-exports.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-exports.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `exports` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `exports` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-files.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-files.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `files` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `files` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-funding.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-funding.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `funding` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `funding` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-gypfile.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-gypfile.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `gypfile` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks that the `gypfile` property, if present, is a boolean.
 

--- a/site/src/content/docs/rules/valid-properties/valid-homepage.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-homepage.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `homepage` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `homepage` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-keywords.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-keywords.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `keywords` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `keywords` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-libc.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-libc.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `libc` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 The rule checks that, if present, the `libc` property is a string or an Array of strings.
 

--- a/site/src/content/docs/rules/valid-properties/valid-license.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-license.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `license` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `license` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-main.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-main.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `main` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks that, if present, the `main` property is a non-empty string.
 

--- a/site/src/content/docs/rules/valid-properties/valid-man.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-man.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `man` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `man` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-module.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-module.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `module` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks that, if present, the `module` property is a non-empty string.
 

--- a/site/src/content/docs/rules/valid-properties/valid-name.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-name.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `name` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `name` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-optionalDependencies.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-optionalDependencies.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `optionalDependencies` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `optionalDependencies` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-os.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-os.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `os` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `os` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-packageManager.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-packageManager.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `packageManager` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `packageManager` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-peerDependencies.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-peerDependencies.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `peerDependencies` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `peerDependencies` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-peerDependenciesMeta.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-peerDependenciesMeta.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `peerDependenciesMeta` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Aside, Tabs, TabItem } from '@astrojs/starlight/components';
+import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `peerDependenciesMeta` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-private.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-private.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `private` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule checks that, present, the `private` property is a boolean.
 

--- a/site/src/content/docs/rules/valid-properties/valid-publishConfig.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-publishConfig.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `publishConfig` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `publishConfig` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-repository.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-repository.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `repository` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `repository` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-scripts.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-scripts.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `scripts` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `scripts` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-sideEffects.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-sideEffects.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `sideEffects` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `sideEffects` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-type.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-type.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `type` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `type` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-version.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-version.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `version` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `version` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-properties/valid-workspaces.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-workspaces.mdx
@@ -7,7 +7,7 @@ description: 'Enforce that the `workspaces` property is valid.'
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule uses [`package-json-validator`](https://github.com/michaelfaith/package-json-validator) to validate the `workspaces` property, if present, against the following criteria:
 

--- a/site/src/content/docs/rules/valid-repository-directory.mdx
+++ b/site/src/content/docs/rules/valid-repository-directory.mdx
@@ -9,7 +9,7 @@ description: 'Enforce that if repository directory is specified, it matches the 
 
 {/* end auto-generated rule header */}
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { TabItem, Tabs } from '@astrojs/starlight/components';
 
 This rule enforces that `"repository"` > `"directory"` points to the right directory for a `package.json`.
 If `"directory"` isn't specified, this rule will do nothing.

--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -1,10 +1,9 @@
+import { AST, Rule, SourceCode } from 'eslint';
 import type * as ESTree from 'estree';
 import type {
   FromSchema as InferJsonSchemaType,
   JSONSchema,
 } from 'json-schema-to-ts';
-
-import { AST, Rule, SourceCode } from 'eslint';
 import { AST as JsonAST, type RuleListener } from 'jsonc-eslint-parser';
 
 import { isPackageJson } from './utils/isPackageJson.ts';

--- a/src/experimental/plugin.ts
+++ b/src/experimental/plugin.ts
@@ -1,5 +1,4 @@
 import type { ESLint } from 'eslint';
-
 import { toCompatRule } from 'eslint-json-compat-utils';
 
 import { plugin as originalPlugin } from '../plugin.ts';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,9 +1,9 @@
-import { type ESLint, type Linter } from 'eslint';
-import * as parserJsonc from 'jsonc-eslint-parser';
 import { createRequire } from 'node:module';
 
-import type { PackageJsonRuleModule } from './createRule.ts';
+import { type ESLint, type Linter } from 'eslint';
+import * as parserJsonc from 'jsonc-eslint-parser';
 
+import type { PackageJsonRuleModule } from './createRule.ts';
 import { rule as binNameCasing } from './rules/bin-name-casing.ts';
 import { rule as exportsSubpathsStyle } from './rules/exports-subpaths-style.ts';
 import { rule as noEmptyFields } from './rules/no-empty-fields.ts';

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -1,10 +1,9 @@
-import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
 import {
   fixRemoveArrayElement,
   fixRemoveObjectProperty,
 } from 'eslint-fix-utils';
+import type * as ESTree from 'estree';
+import type { AST as JsonAST } from 'jsonc-eslint-parser';
 
 import { createRule, PackageJsonRuleContext } from '../createRule.ts';
 

--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -1,7 +1,6 @@
+import { fixRemoveArrayElement } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
 import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
-import { fixRemoveArrayElement } from 'eslint-fix-utils';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral, isNotNullish } from '../utils/predicates.ts';

--- a/src/rules/no-redundant-publishConfig.ts
+++ b/src/rules/no-redundant-publishConfig.ts
@@ -1,7 +1,6 @@
+import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
 import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
-import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';

--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -1,7 +1,6 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
 import detectIndent from 'detect-indent';
 import { detectNewlineGraceful } from 'detect-newline';
+import type { AST as JsonAST } from 'jsonc-eslint-parser';
 import sortObjectKeys from 'sort-object-keys';
 import { sortOrder } from 'sort-package-json';
 

--- a/src/rules/require-attribution.ts
+++ b/src/rules/require-attribution.ts
@@ -1,7 +1,6 @@
+import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
 import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
-import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 
 import { createRule } from '../createRule.ts';
 

--- a/src/rules/require-properties.ts
+++ b/src/rules/require-properties.ts
@@ -1,6 +1,6 @@
 import {
-  type CreateRequirePropertyRuleOptions,
   createSimpleRequirePropertyRule,
+  type CreateRequirePropertyRuleOptions,
 } from '../utils/createSimpleRequirePropertyRule.js';
 
 export const propertyConfig: [

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -1,5 +1,4 @@
 import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
 import semver from 'semver';
 
 import { createRule } from '../createRule.ts';

--- a/src/rules/restrict-private-properties.ts
+++ b/src/rules/restrict-private-properties.ts
@@ -1,7 +1,6 @@
+import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
 import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
-import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';

--- a/src/rules/restrict-top-level-properties.ts
+++ b/src/rules/restrict-top-level-properties.ts
@@ -1,6 +1,5 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
 import { fixRemoveObjectProperty, type ObjectProperty } from 'eslint-fix-utils';
+import type { AST as JsonAST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -1,5 +1,4 @@
 import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
 import sortPackageJson from 'sort-package-json';
 
 import { createRule } from '../createRule.ts';

--- a/src/rules/unique-dependencies.ts
+++ b/src/rules/unique-dependencies.ts
@@ -1,10 +1,9 @@
-import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
 import {
   fixRemoveArrayElement,
   fixRemoveObjectProperty,
 } from 'eslint-fix-utils';
+import type * as ESTree from 'estree';
+import type { AST as JsonAST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral, isNotNullish } from '../utils/predicates.ts';

--- a/src/rules/valid-peerDependenciesMeta-relationship.ts
+++ b/src/rules/valid-peerDependenciesMeta-relationship.ts
@@ -1,7 +1,6 @@
+import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
 import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
-import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';

--- a/src/rules/valid-repository-directory.ts
+++ b/src/rules/valid-repository-directory.ts
@@ -1,8 +1,8 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
-
-import { findRootSync } from '@altano/repository-tools';
 import path from 'node:path';
 import { sep as posixSep } from 'node:path/posix';
+
+import { findRootSync } from '@altano/repository-tools';
+import type { AST as JsonAST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { findPropertyWithKeyValue } from '../utils/findPropertyWithKeyValue.ts';

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,6 +1,7 @@
-import { ESLint, Linter } from 'eslint';
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
+
+import { ESLint, Linter } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
 import plugin from '../index.ts';

--- a/src/tests/rules/require-properties.test.ts
+++ b/src/tests/rules/require-properties.test.ts
@@ -1,5 +1,4 @@
 import type { PackageJsonPluginSettings } from '../../createRule.ts';
-
 import { propertyConfig, rules } from '../../rules/require-properties.ts';
 import { ruleTester } from './ruleTester.ts';
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change turns off `perfectionist/sort-imports` on the eslint side, in favor of using `@ianvs/prettier-plugin-sort-imports`.
