### PR TITLE
perf(valid-repository-directory): cache repo root for improved performance in monorepos

### DIFF
--- a/src/rules/valid-repository-directory.ts
+++ b/src/rules/valid-repository-directory.ts
@@ -14,7 +14,7 @@ import { findPropertyWithKeyValue } from '../utils/findPropertyWithKeyValue.ts';
  * @example '/a/b/c', 'b' => false
  * @example '/a/b/c', 'd' => false
  */
-function pathEndsWith(parent: string, child: string): boolean {
+const pathEndsWith = (parent: string, child: string): boolean => {
   const segments = parent.split(path.sep);
 
   if (parent === child) {
@@ -31,7 +31,9 @@ function pathEndsWith(parent: string, child: string): boolean {
       return true;
     }
   });
-}
+};
+
+let repoRootCache: null | string = null;
 
 export const rule = createRule({
   create(context) {
@@ -54,30 +56,17 @@ export const rule = createRule({
 
         const directoryValue = directoryProperty.value.value;
         const fileDirectory = path.normalize(path.dirname(context.filename));
-        const repositoryRoot = findRootSync(fileDirectory);
-
-        if (repositoryRoot == null) {
-          // Since we couldn't determine the repository root, we can't
-          // rigorously determine the validity of the directory value.
-          // But, we can at least make sure the directory value
-          // appears at the end of the package.json file path. For
-          // example:
-          //
-          //   if /a/b/c/package.json has the value: directory: "b/c"
-          //   it will validate
-          //
-          //   if /a/b/c/package.json has the value: directory: "b/d"
-          //   it will NOT validate
-          //
-          // This ensures that the directory value is at least
-          // partially correct.
-          if (!pathEndsWith(fileDirectory, path.normalize(directoryValue))) {
-            context.report({
-              messageId: 'mismatched',
-              node: directoryProperty.value,
-            });
-          }
+        let repositoryRoot;
+        if (repoRootCache && fileDirectory.startsWith(repoRootCache)) {
+          repositoryRoot = repoRootCache;
         } else {
+          repositoryRoot = findRootSync(fileDirectory);
+          if (repositoryRoot) {
+            repoRootCache = path.normalize(repositoryRoot);
+          }
+        }
+
+        if (repositoryRoot) {
           // Get the relative path from repository root to
           // package.json. For example:
           //
@@ -112,6 +101,27 @@ export const rule = createRule({
                   messageId: 'replace',
                 },
               ],
+            });
+          }
+        } else {
+          // Since we couldn't determine the repository root, we can't
+          // rigorously determine the validity of the directory value.
+          // But, we can at least make sure the directory value
+          // appears at the end of the package.json file path. For
+          // example:
+          //
+          //   if /a/b/c/package.json has the value: directory: "b/c"
+          //   it will validate
+          //
+          //   if /a/b/c/package.json has the value: directory: "b/d"
+          //   it will NOT validate
+          //
+          // This ensures that the directory value is at least
+          // partially correct.
+          if (!pathEndsWith(fileDirectory, path.normalize(directoryValue))) {
+            context.report({
+              messageId: 'mismatched',
+              node: directoryProperty.value,
             });
           }
         }


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1906 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a cache for the repo root in `valid-repository-directory`.  It was previously running `git rev-parse` for every invocation of the rule in order to get the repo root dir.  In a monorepo, where this is run numerous times, but the repo root is the same, it's quite inefficient.  Now, we're "lightly" caching the repo root, so we only have to make the call once in most cases.
