### PR TITLE
Add explicit type annotation to configs export

### DIFF
--- a/src/experimental/index.ts
+++ b/src/experimental/index.ts
@@ -2,7 +2,7 @@ import { plugin } from './plugin.ts';
 
 export type { PackageJsonPluginSettings } from '../createRule.ts';
 
-export const configs = plugin.configs;
+export const configs: typeof plugin.configs = plugin.configs;
 export const rules = plugin.rules;
 
 export default plugin;


### PR DESCRIPTION
## Problem
The exported `configs` constant lacks an explicit type annotation, relying on type inference from the imported `plugin` object. This can reduce type safety and code readability, potentially making the code harder to understand and maintain.

## Changes
- Added a `typeof plugin.configs` type annotation to the `configs` export in `src/experimental/index.ts` to explicitly define its type.

## Verification
- Run the TypeScript compiler to ensure type checking passes without errors.
- Execute the existing test suite to confirm that no functional behavior is altered and all tests continue to pass.