### PR TITLE
docs: fix markdown table rendering

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       title: 'ESLint Plugin: Package JSON',
     }),
   ],
+  markdown: { gfm: true },
   outDir: './dist-site',
   prefetch: {
     defaultStrategy: 'hover',


### PR DESCRIPTION
Astro's 6.4.0 update broke markdown rendering in Starlight (https://github.com/withastro/starlight/issues/3934).  This is a workaround suggested in that thread.  We can remove it, once a fix for that has landed.

<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
