### PR TITLE
docs: add project docs to our website

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,6 +2,7 @@
 
 Thanks for your interest in contributing to `eslint-plugin-package-json`! 🗂
 
+> [!TIP]
 > After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
 
 ## Code of Conduct

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -8,11 +8,10 @@ cd eslint-plugin-package-json
 pnpm install
 ```
 
-:::tip
-This repository includes a list of suggested VS Code extensions.
-We recommend using [VS Code](https://code.visualstudio.com), [Cursor](https://cursor.com), or another VS Code-compatible IDE and accept its prompt to install them.
-If you're not using VS Code, use the equivalent extensions for your editor.
-:::
+> [!TIP]
+> This repository includes a list of suggested VS Code extensions.
+> We recommend using [VS Code](https://code.visualstudio.com), [Cursor](https://cursor.com), or another VS Code-compatible IDE and accept its prompt to install them.
+> If you're not using VS Code, use the equivalent extensions for your editor.
 
 ## Building
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -28,6 +28,15 @@ export default defineConfig({
           items: [{ autogenerate: { collapsed: true, directory: 'rules' } }],
           label: 'Rules',
         },
+        {
+          collapsed: true,
+          items: [
+            {
+              autogenerate: { collapsed: true, directory: 'getting-involved' },
+            },
+          ],
+          label: 'Getting Involved',
+        },
       ],
       social: [
         {

--- a/site/src/content/docs/getting-involved/code-of-conduct.md
+++ b/site/src/content/docs/getting-involved/code-of-conduct.md
@@ -1,4 +1,7 @@
-# Code of Conduct
+---
+title: Code of Conduct
+description: 'Expectations for how we work as a diverse, inclusive, and healthy community.'
+---
 
 ## Our Pledge
 

--- a/site/src/content/docs/getting-involved/contributing-with-ai.md
+++ b/site/src/content/docs/getting-involved/contributing-with-ai.md
@@ -1,0 +1,22 @@
+---
+title: Contributing with AI
+description: 'How we will or will not work with AI / LLM based contributions.'
+---
+
+With the rise of AI-assisted coding tools, it has become easier than ever to generate large amounts of low-quality contributions, for PRs and issues.
+Parsing, reviewing, and iterating on these in good faith takes up much more maintainer bandwidth than traditional contributions, taking away bandwidth from other opportunities to advance this project.
+
+While we cannot and will not attempt to ban contributions which make use of AI, we ask that you use AI responsibly:
+
+1. Always review AI-generated code closely before submitting a PR.
+2. Only use AI to assist in contributions that you would understand well enough to work on and respond to feedback on without making use of AI.
+3. Do not ignore our issue and PR templates.
+4. Avoid AI-generated content in written, non-code contributions (issues/comments/PR descriptions, etc.).
+   - AI PR descriptions that are just word-for-word descriptions of the diff add no value.
+   - Instead, summarize the PR succinctly in your own words, relying on your own understanding of the code.
+
+Pull requests and issues that do not appear to follow these guidelines may be closed at maintainers' discretion.
+
+Don't let this dissuade you from contributing!
+We very much welcome new contributors and are happy to help them improve.
+We just cannot afford to spend our time supporting contributors who primarily defer to AI coding assistants; at that point it'd be a better use of our time to prompt the LLM ourselves.

--- a/site/src/content/docs/getting-involved/contributing.mdx
+++ b/site/src/content/docs/getting-involved/contributing.mdx
@@ -1,12 +1,20 @@
-# Contributing
+---
+title: Contributing
+description: 'How to effectively contribute to this project.'
+---
 
-Thanks for your interest in contributing to `eslint-plugin-package-json`! 🗂
+import { Aside } from '@astrojs/starlight/components';
 
-> After this page, see [DEVELOPMENT.md](./DEVELOPMENT.md) for local development instructions.
+Thanks for your interest in contributing to `eslint-plugin-package-json`!
+
+<Aside type="tip">
+  After this page, see our [Development](,/development) page for local
+  development instructions.
+</Aside>
 
 ## Code of Conduct
 
-This project has a [Code of Conduct](./CODE_OF_CONDUCT.md) all contributors are expected to follow.
+This project has a [Code of Conduct](./code-of-conduct) all contributors are expected to follow.
 
 ## Reporting Issues
 
@@ -80,7 +88,7 @@ Once all feedback is addressed and the PR is approved, we'll ensure the branch i
 
 #### Post-Merge Recognition
 
-Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the README.md](../README.md#contributors) for its [type of contribution](https://allcontributors.org/en/emoji-key/ 'Allcontributors emoji key'), you should be soon.
+Once your PR is merged, if you haven't yet been added to the [_Contributors_ table in the repo's README.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/README.md#contributors) for its [type of contribution](https://allcontributors.org/en/emoji-key/ 'Allcontributors emoji key'), you should be soon.
 Please do ping the maintainer who merged your PR if that doesn't happen within 24 hours - it was likely an oversight on our end!
 
 ## Emojis & Appreciation

--- a/site/src/content/docs/getting-involved/development.mdx
+++ b/site/src/content/docs/getting-involved/development.mdx
@@ -1,4 +1,9 @@
-# Development
+---
+title: Development
+description: 'Details for how to work in our codebase.'
+---
+
+import { Aside } from '@astrojs/starlight/components';
 
 After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo) and [installing pnpm](https://pnpm.io/installation), run the following:
 
@@ -8,11 +13,12 @@ cd eslint-plugin-package-json
 pnpm install
 ```
 
-:::tip
-This repository includes a list of suggested VS Code extensions.
-We recommend using [VS Code](https://code.visualstudio.com), [Cursor](https://cursor.com), or another VS Code-compatible IDE and accept its prompt to install them.
-If you're not using VS Code, use the equivalent extensions for your editor.
-:::
+<Aside type="tip">
+  This repository includes a list of suggested VS Code extensions. We recommend
+  using [VS Code](https://code.visualstudio.com), [Cursor](https://cursor.com),
+  or another VS Code-compatible IDE and accept its prompt to install them. If
+  you're not using VS Code, use the equivalent extensions for your editor.
+</Aside>
 
 ## Building
 


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1738
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a "Getting Involved" section to our doc site, with the following pages:
- Code of Conduct
- Contributing
- Contributing with AI
- Development
