### PR TITLE
fix(sort-collections): improve fixer's indent-matching logic

### DIFF
--- a/src/rules/bin-name-casing.ts
+++ b/src/rules/bin-name-casing.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from 'change-case';
-import { AST as JsonAST } from 'jsonc-eslint-parser';
+import { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 
@@ -7,11 +7,11 @@ export const rule = createRule({
   create(context) {
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=bin]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         if (node.value.type === 'JSONObjectExpression') {
           for (const property of node.value.properties) {
-            const key = property.key as JsonAST.JSONStringLiteral;
+            const key = property.key as AST.JSONStringLiteral;
             const kebabCaseKey = kebabCase(key.value);
             if (kebabCaseKey !== key.value) {
               context.report({

--- a/src/rules/exports-subpaths-style.ts
+++ b/src/rules/exports-subpaths-style.ts
@@ -1,10 +1,10 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';
 
 function isImplicitFormat(
-  node: JsonAST.JSONLiteral | JsonAST.JSONObjectExpression,
+  node: AST.JSONLiteral | AST.JSONObjectExpression,
 ): boolean {
   if (node.type === 'JSONLiteral') {
     return true;
@@ -22,7 +22,7 @@ export const rule = createRule({
   create(context) {
     const [{ prefer = 'explicit' } = {}] = context.options;
 
-    function validateForExplicit(node: JsonAST.JSONProperty) {
+    function validateForExplicit(node: AST.JSONProperty) {
       const { value } = node;
       if (
         (value.type !== 'JSONLiteral' &&
@@ -48,7 +48,7 @@ export const rule = createRule({
       });
     }
 
-    function validateForImplicit(node: JsonAST.JSONProperty) {
+    function validateForImplicit(node: AST.JSONProperty) {
       const { value } = node;
       if (value.type !== 'JSONObjectExpression') {
         return;

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -3,15 +3,12 @@ import {
   fixRemoveObjectProperty,
 } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule, PackageJsonRuleContext } from '../createRule.ts';
 
 const getDataAndMessageId = (
-  node:
-    | JsonAST.JSONArrayExpression
-    | JsonAST.JSONObjectExpression
-    | JsonAST.JSONProperty,
+  node: AST.JSONArrayExpression | AST.JSONObjectExpression | AST.JSONProperty,
 ): {
   data: Record<string, string>;
   messageId: 'emptyExpression' | 'emptyFields';
@@ -34,7 +31,7 @@ const getDataAndMessageId = (
     case 'JSONProperty':
       return {
         data: {
-          field: (node.key as JsonAST.JSONStringLiteral).value,
+          field: (node.key as AST.JSONStringLiteral).value,
         },
         messageId: 'emptyFields',
       };
@@ -43,10 +40,7 @@ const getDataAndMessageId = (
 
 const report = (
   context: PackageJsonRuleContext,
-  node:
-    | JsonAST.JSONArrayExpression
-    | JsonAST.JSONObjectExpression
-    | JsonAST.JSONProperty,
+  node: AST.JSONArrayExpression | AST.JSONObjectExpression | AST.JSONProperty,
 ) => {
   const { data, messageId } = getDataAndMessageId(node);
   context.report({
@@ -72,16 +66,14 @@ const report = (
   });
 };
 
-const getNode = (
-  node: JsonAST.JSONArrayExpression | JsonAST.JSONObjectExpression,
-) => {
+const getNode = (node: AST.JSONArrayExpression | AST.JSONObjectExpression) => {
   return node.parent.type === 'JSONProperty' ? node.parent : node;
 };
 
 const getTopLevelProperty = (
-  node: JsonAST.JSONArrayExpression | JsonAST.JSONObjectExpression,
-): JsonAST.JSONStringLiteral | undefined => {
-  let n: JsonAST.JSONNode = node;
+  node: AST.JSONArrayExpression | AST.JSONObjectExpression,
+): AST.JSONStringLiteral | undefined => {
+  let n: AST.JSONNode = node;
   while (
     n.parent.parent?.parent?.type !== undefined &&
     n.parent.parent.parent.type !== 'Program'
@@ -89,7 +81,7 @@ const getTopLevelProperty = (
     n = n.parent;
   }
   return n.type === 'JSONProperty'
-    ? (n.key as JsonAST.JSONStringLiteral)
+    ? (n.key as AST.JSONStringLiteral)
     : undefined;
 };
 

--- a/src/rules/no-local-dependencies.ts
+++ b/src/rules/no-local-dependencies.ts
@@ -1,4 +1,4 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';
@@ -15,12 +15,12 @@ export const rule = createRule({
   create(context) {
     const ignorePrivate = context.options[0]?.ignorePrivate ?? true;
     let isPrivate = false;
-    let dependencyNodes: JsonAST.JSONProperty[] = [];
+    let dependencyNodes: AST.JSONProperty[] = [];
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.type=JSONLiteral][value.type=JSONLiteral][key.value=private]'(
-        node: JsonAST.JSONProperty & {
-          value: JsonAST.JSONKeywordLiteral;
+        node: AST.JSONProperty & {
+          value: AST.JSONKeywordLiteral;
         },
       ) {
         if (node.value.value === true) {
@@ -28,8 +28,8 @@ export const rule = createRule({
         }
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.type=JSONLiteral][value.type=JSONObjectExpression][key.value=dependencies]'(
-        node: JsonAST.JSONProperty & {
-          value: JsonAST.JSONObjectExpression;
+        node: AST.JSONProperty & {
+          value: AST.JSONObjectExpression;
         },
       ) {
         dependencyNodes = node.value.properties;

--- a/src/rules/no-redundant-files.ts
+++ b/src/rules/no-redundant-files.ts
@@ -1,6 +1,6 @@
 import { fixRemoveArrayElement } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral, isNotNullish } from '../utils/predicates.ts';
@@ -39,12 +39,12 @@ export const rule = createRule({
     // the other values to ensure that files doesn't contain duplicates.
     const entryCache: {
       bin: string[];
-      files: (JsonAST.JSONExpression | null)[];
+      files: (AST.JSONExpression | null)[];
       main?: string;
     } = { bin: [], files: [] };
 
     const report = (
-      elements: (JsonAST.JSONExpression | null)[],
+      elements: (AST.JSONExpression | null)[],
       index: number,
       messageId: string,
     ) => {
@@ -71,7 +71,7 @@ export const rule = createRule({
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=bin]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         const binValue = node.value;
 
@@ -89,7 +89,7 @@ export const rule = createRule({
         }
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=files]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         // "files" should only ever be an array of strings.
         if (node.value.type === 'JSONArrayExpression') {
@@ -121,7 +121,7 @@ export const rule = createRule({
         }
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=main]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         // "main" should only ever be a string.
         if (isJSONStringLiteral(node.value)) {

--- a/src/rules/no-redundant-publishConfig.ts
+++ b/src/rules/no-redundant-publishConfig.ts
@@ -1,6 +1,6 @@
 import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';
@@ -8,18 +8,18 @@ import { isJSONStringLiteral } from '../utils/predicates.ts';
 export const rule = createRule({
   create(context) {
     let packageName: string | undefined;
-    let publishConfigAccessProperty: JsonAST.JSONProperty | undefined;
+    let publishConfigAccessProperty: AST.JSONProperty | undefined;
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=name]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         if (isJSONStringLiteral(node.value)) {
           packageName = node.value.value;
         }
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=publishConfig]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         if (node.value.type !== 'JSONObjectExpression') {
           return;

--- a/src/rules/order-properties.ts
+++ b/src/rules/order-properties.ts
@@ -1,6 +1,6 @@
 import detectIndent from 'detect-indent';
 import { detectNewlineGraceful } from 'detect-newline';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 import sortObjectKeys from 'sort-object-keys';
 import { sortOrder } from 'sort-package-json';
 
@@ -32,7 +32,7 @@ export const rule = createRule({
         const { properties } = ast.body[0].expression;
 
         for (let i = 0; i < properties.length; i += 1) {
-          const property = properties[i].key as JsonAST.JSONStringLiteral;
+          const property = properties[i].key as AST.JSONStringLiteral;
           const { value } = property;
 
           if (value === orderedKeys[i]) {

--- a/src/rules/repository-shorthand.ts
+++ b/src/rules/repository-shorthand.ts
@@ -1,4 +1,4 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { findPropertyWithKeyValue } from '../utils/findPropertyWithKeyValue.ts';
@@ -54,7 +54,7 @@ export const rule = createRule({
   create(context) {
     const [{ form = 'object' } = {}] = context.options;
 
-    function validateRepositoryForObject(node: JsonAST.JSONProperty) {
+    function validateRepositoryForObject(node: AST.JSONProperty) {
       if (isJSONStringLiteral(node.value)) {
         context.report({
           fix(fixer) {
@@ -83,7 +83,7 @@ export const rule = createRule({
       }
     }
 
-    function validateRepositoryForShorthand(node: JsonAST.JSONProperty) {
+    function validateRepositoryForShorthand(node: AST.JSONProperty) {
       if (isJSONStringLiteral(node.value)) {
         const { value } = node.value;
         const provider = getProviderFromUrl(value);

--- a/src/rules/require-attribution.ts
+++ b/src/rules/require-attribution.ts
@@ -1,6 +1,6 @@
 import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 
@@ -9,18 +9,18 @@ export const rule = createRule({
     const preferContributorsOnly =
       context.options[0]?.preferContributorsOnly ?? false;
     const ignorePrivate = context.options[0]?.ignorePrivate ?? true;
-    let authorPropertyNode: JsonAST.JSONProperty | undefined;
-    let contributorsPropertyNode: JsonAST.JSONProperty | undefined;
+    let authorPropertyNode: AST.JSONProperty | undefined;
+    let contributorsPropertyNode: AST.JSONProperty | undefined;
     let isPrivatePackage = false;
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=author]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         authorPropertyNode = node;
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=contributors]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         contributorsPropertyNode = node;
 
@@ -37,7 +37,7 @@ export const rule = createRule({
         }
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=private]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         if (node.value.type === 'JSONLiteral' && node.value.value === true) {
           isPrivatePackage = true;

--- a/src/rules/restrict-dependency-ranges.ts
+++ b/src/rules/restrict-dependency-ranges.ts
@@ -1,4 +1,4 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 import semver from 'semver';
 
 import { createRule } from '../createRule.ts';
@@ -123,9 +123,9 @@ export const rule = createRule({
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.type=JSONLiteral][value.type=JSONObjectExpression]'(
-        node: JsonAST.JSONProperty & {
-          key: JsonAST.JSONStringLiteral;
-          value: JsonAST.JSONObjectExpression;
+        node: AST.JSONProperty & {
+          key: AST.JSONStringLiteral;
+          value: AST.JSONObjectExpression;
         },
       ) {
         const dependencyType = node.key.value;

--- a/src/rules/restrict-private-properties.ts
+++ b/src/rules/restrict-private-properties.ts
@@ -1,6 +1,6 @@
 import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';
@@ -15,7 +15,7 @@ export const rule = createRule({
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression'(
-        node: JsonAST.JSONObjectExpression,
+        node: AST.JSONObjectExpression,
       ) {
         // Check if this is a private package
         if (
@@ -50,10 +50,7 @@ export const rule = createRule({
               node: property,
               ...(isEmpty
                 ? {
-                    fix: fixRemoveObjectProperty(
-                      context,
-                      property as unknown as ESTree.Property,
-                    ),
+                    fix: fixRemoveObjectProperty(context, property),
                   }
                 : {
                     suggest: [
@@ -61,10 +58,7 @@ export const rule = createRule({
                         data: {
                           property: property.key.value,
                         },
-                        fix: fixRemoveObjectProperty(
-                          context,
-                          property as unknown as ESTree.Property,
-                        ),
+                        fix: fixRemoveObjectProperty(context, property),
                         messageId: 'removePropertySuggestion',
                       },
                     ],

--- a/src/rules/restrict-private-properties.ts
+++ b/src/rules/restrict-private-properties.ts
@@ -50,7 +50,10 @@ export const rule = createRule({
               node: property,
               ...(isEmpty
                 ? {
-                    fix: fixRemoveObjectProperty(context, property),
+                    fix: fixRemoveObjectProperty(
+                      context,
+                      property as unknown as ESTree.Property,
+                    ),
                   }
                 : {
                     suggest: [
@@ -58,7 +61,10 @@ export const rule = createRule({
                         data: {
                           property: property.key.value,
                         },
-                        fix: fixRemoveObjectProperty(context, property),
+                        fix: fixRemoveObjectProperty(
+                          context,
+                          property as unknown as ESTree.Property,
+                        ),
                         messageId: 'removePropertySuggestion',
                       },
                     ],

--- a/src/rules/restrict-top-level-properties.ts
+++ b/src/rules/restrict-top-level-properties.ts
@@ -1,5 +1,5 @@
 import { fixRemoveObjectProperty, type ObjectProperty } from 'eslint-fix-utils';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';
@@ -17,7 +17,7 @@ export const rule = createRule({
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression'(
-        node: JsonAST.JSONObjectExpression,
+        node: AST.JSONObjectExpression,
       ) {
         for (const property of node.properties) {
           if (!isJSONStringLiteral(property.key)) {

--- a/src/rules/scripts-name-casing.ts
+++ b/src/rules/scripts-name-casing.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from 'change-case';
-import { AST as JsonAST } from 'jsonc-eslint-parser';
+import { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 
@@ -10,11 +10,11 @@ export const rule = createRule({
   create(context) {
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=scripts]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         if (node.value.type === 'JSONObjectExpression') {
           for (const property of node.value.properties) {
-            const keyNode = property.key as JsonAST.JSONStringLiteral;
+            const keyNode = property.key as AST.JSONStringLiteral;
             const key = keyNode.value;
             if (BUILT_IN_SCRIPTS_IN_CAMEL_CASE.has(key)) {
               continue;

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -110,7 +110,7 @@ export const rule = createRule({
                 JSON.stringify(
                   desiredOrder.reduce<Record<string, unknown>>(
                     (out, property) => {
-                      out[(property.key as JsonAST.JSONStringLiteral).value] =
+                      out[(property.key as AST.JSONStringLiteral).value] =
                         JSON.parse(context.sourceCode.getText(property.value));
                       return out;
                     },

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -1,4 +1,4 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 import sortPackageJson from 'sort-package-json';
 
 import { createRule } from '../createRule.ts';
@@ -36,7 +36,7 @@ export const rule = createRule({
 
         const keyPartsReversed = [nodeKey.value];
         for (
-          let currNode: JsonAST.JSONNode | null | undefined = node.parent;
+          let currNode: AST.JSONNode | null | undefined = node.parent;
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           currNode;
           currNode = currNode.parent
@@ -87,8 +87,8 @@ export const rule = createRule({
         const rank = (k: string) => orderIndex.get(k) ?? orderIndex.size;
 
         const desiredOrder = currentOrder.toSorted((a, b) => {
-          const aKey = (a.key as JsonAST.JSONStringLiteral).value;
-          const bKey = (b.key as JsonAST.JSONStringLiteral).value;
+          const aKey = (a.key as AST.JSONStringLiteral).value;
+          const bKey = (b.key as AST.JSONStringLiteral).value;
           const ai = rank(aKey);
           const bi = rank(bKey);
 

--- a/src/rules/sort-collections.ts
+++ b/src/rules/sort-collections.ts
@@ -1,3 +1,5 @@
+import detectIndent from 'detect-indent';
+import { detectNewlineGraceful } from 'detect-newline';
 import type { AST } from 'jsonc-eslint-parser';
 import sortPackageJson from 'sort-package-json';
 
@@ -105,23 +107,39 @@ export const rule = createRule({
               key,
             },
             fix(fixer) {
-              return fixer.replaceText(
-                collection,
-                JSON.stringify(
-                  desiredOrder.reduce<Record<string, unknown>>(
-                    (out, property) => {
-                      out[(property.key as AST.JSONStringLiteral).value] =
-                        JSON.parse(context.sourceCode.getText(property.value));
-                      return out;
-                    },
-                    {},
-                  ),
-                  null,
-                  2,
-                )
-                  .split('\n')
-                  .join('\n  '), // nest indents
+              const { text } = context.sourceCode;
+              const { indent, type } = detectIndent(text);
+              const newline = detectNewlineGraceful(text);
+              const indentUnit = type === 'tab' ? '\t' : indent || '  ';
+
+              const replacementJson = JSON.stringify(
+                desiredOrder.reduce<Record<string, unknown>>(
+                  (out, property) => {
+                    out[(property.key as AST.JSONStringLiteral).value] =
+                      JSON.parse(context.sourceCode.getText(property.value));
+                    return out;
+                  },
+                  {},
+                ),
+                null,
+                indentUnit,
               );
+
+              const jsonLines = replacementJson.split('\n');
+
+              const collectionStartLine = collection.loc.start.line;
+              const lineText =
+                context.sourceCode.lines[collectionStartLine - 1];
+              const leadingWhitespaceMatch = /^\s*/.exec(lineText);
+              const leadingWhitespace = leadingWhitespaceMatch
+                ? leadingWhitespaceMatch[0]
+                : '';
+
+              const result = jsonLines
+                .map((l, i) => (i === 0 ? l : leadingWhitespace + l))
+                .join(newline);
+
+              return fixer.replaceText(collection, result);
             },
             loc: collection.loc,
             messageId: customOrder

--- a/src/rules/specify-peers-locally.ts
+++ b/src/rules/specify-peers-locally.ts
@@ -1,4 +1,4 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';
@@ -6,13 +6,13 @@ import { isJSONStringLiteral } from '../utils/predicates.ts';
 export const rule = createRule({
   create(context) {
     const devDependencyNames = new Set<string>();
-    let devDependenciesObjectNode: JsonAST.JSONObjectExpression | undefined;
-    const peerDependencyMap: Record<string, JsonAST.JSONProperty> = {};
+    let devDependenciesObjectNode: AST.JSONObjectExpression | undefined;
+    const peerDependencyMap: Record<string, AST.JSONProperty> = {};
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.type=JSONLiteral][value.type=JSONObjectExpression][key.value=devDependencies]'(
-        node: JsonAST.JSONProperty & {
-          value: JsonAST.JSONObjectExpression;
+        node: AST.JSONProperty & {
+          value: AST.JSONObjectExpression;
         },
       ) {
         devDependenciesObjectNode = node.value;
@@ -24,8 +24,8 @@ export const rule = createRule({
         }
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.type=JSONLiteral][value.type=JSONObjectExpression][key.value=peerDependencies]'(
-        node: JsonAST.JSONProperty & {
-          value: JsonAST.JSONObjectExpression;
+        node: AST.JSONProperty & {
+          value: AST.JSONObjectExpression;
         },
       ) {
         for (const peerDependencyPropertyNode of node.value.properties) {

--- a/src/rules/unique-dependencies.ts
+++ b/src/rules/unique-dependencies.ts
@@ -3,7 +3,7 @@ import {
   fixRemoveObjectProperty,
 } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral, isNotNullish } from '../utils/predicates.ts';
@@ -20,7 +20,7 @@ const dependencyPropertyNames = new Set([
 
 export const rule = createRule({
   create(context) {
-    const dependenciesCache: Record<string, JsonAST.JSONProperty[]> = {
+    const dependenciesCache: Record<string, AST.JSONProperty[]> = {
       dependencies: [],
       devDependencies: [],
       peerDependencies: [],
@@ -28,8 +28,8 @@ export const rule = createRule({
     const trackForCrossGroupUniqueness = Object.keys(dependenciesCache);
 
     function check(
-      elements: (JsonAST.JSONNode | null)[],
-      getNodeToRemove: (element: JsonAST.JSONNode) => JsonAST.JSONNode,
+      elements: (AST.JSONNode | null)[],
+      getNodeToRemove: (element: AST.JSONNode) => AST.JSONNode,
     ) {
       const seen = new Set();
 
@@ -44,7 +44,7 @@ export const rule = createRule({
         }
       }
 
-      function report(node: JsonAST.JSONNode) {
+      function report(node: AST.JSONNode) {
         const removal = getNodeToRemove(node);
         context.report({
           messageId: 'overridden',
@@ -71,8 +71,8 @@ export const rule = createRule({
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.type=JSONLiteral]'(
-        node: JsonAST.JSONProperty & {
-          key: JsonAST.JSONStringLiteral;
+        node: AST.JSONProperty & {
+          key: AST.JSONStringLiteral;
         },
       ) {
         if (!dependencyPropertyNames.has(node.key.value)) {

--- a/src/rules/valid-peerDependenciesMeta-relationship.ts
+++ b/src/rules/valid-peerDependenciesMeta-relationship.ts
@@ -1,6 +1,6 @@
 import { fixRemoveObjectProperty } from 'eslint-fix-utils';
 import type * as ESTree from 'estree';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from '../utils/predicates.ts';
@@ -8,11 +8,11 @@ import { isJSONStringLiteral } from '../utils/predicates.ts';
 export const rule = createRule({
   create(context) {
     const peerDependencies = new Set<string>();
-    const peerDependenciesMeta = new Map<string, JsonAST.JSONProperty>();
+    const peerDependenciesMeta = new Map<string, AST.JSONProperty>();
 
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=peerDependencies]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         if (node.value.type === 'JSONObjectExpression') {
           for (const property of node.value.properties) {
@@ -23,7 +23,7 @@ export const rule = createRule({
         }
       },
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=peerDependenciesMeta]'(
-        node: JsonAST.JSONProperty,
+        node: AST.JSONProperty,
       ) {
         if (node.value.type === 'JSONObjectExpression') {
           for (const property of node.value.properties) {

--- a/src/rules/valid-repository-directory.ts
+++ b/src/rules/valid-repository-directory.ts
@@ -2,7 +2,7 @@ import path from 'node:path';
 import { sep as posixSep } from 'node:path/posix';
 
 import { findRootSync } from '@altano/repository-tools';
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { findPropertyWithKeyValue } from '../utils/findPropertyWithKeyValue.ts';
@@ -39,8 +39,8 @@ export const rule = createRule({
   create(context) {
     return {
       'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=repository][value.type=JSONObjectExpression]'(
-        node: JsonAST.JSONProperty & {
-          value: JsonAST.JSONObjectExpression;
+        node: AST.JSONProperty & {
+          value: AST.JSONObjectExpression;
         },
       ) {
         const directoryProperty = findPropertyWithKeyValue(

--- a/src/tests/rules/sort-collections.test.ts
+++ b/src/tests/rules/sort-collections.test.ts
@@ -9,10 +9,10 @@ ruleTester.run('sort-collections', rule, {
   invalid: [
     {
       code: `{
-	"scripts": {
-		"watch": "webpack-dev-server",
-		"build": "webpack"
-	}
+  "scripts": {
+    "watch": "webpack-dev-server",
+    "build": "webpack"
+  }
 }`,
       errors: [
         {
@@ -22,7 +22,7 @@ ruleTester.run('sort-collections', rule, {
       ],
       filename: 'package.json',
       output: `{
-	"scripts": {
+  "scripts": {
     "build": "webpack",
     "watch": "webpack-dev-server"
   }
@@ -46,11 +46,11 @@ ruleTester.run('sort-collections', rule, {
       filename: 'package.json',
       output: `{
 	"scripts": {
-    "prebuild": "echo test",
-    "build": "webpack",
-    "watch": "webpack-dev-server",
-    "postwatch": "echo test"
-  }
+		"prebuild": "echo test",
+		"build": "webpack",
+		"watch": "webpack-dev-server",
+		"postwatch": "echo test"
+	}
 }`,
     },
     {
@@ -69,9 +69,9 @@ ruleTester.run('sort-collections', rule, {
       filename: 'package.json',
       output: `{
 	"scripts": {
-    "build": "echo test",
-    "postbuild": "echo test"
-  }
+		"build": "echo test",
+		"postbuild": "echo test"
+	}
 }`,
     },
     {
@@ -90,9 +90,9 @@ ruleTester.run('sort-collections', rule, {
       filename: 'package.json',
       output: `{
 	"scripts": {
-    "prebuild": "echo test",
-    "build": "echo test"
-  }
+		"prebuild": "echo test",
+		"build": "echo test"
+	}
 }`,
     },
     {
@@ -111,9 +111,9 @@ ruleTester.run('sort-collections', rule, {
       filename: 'package.json',
       output: `{
 	"scripts": {
-    "postbuild": "echo test",
-    "prebuild": "echo test"
-  }
+		"postbuild": "echo test",
+		"prebuild": "echo test"
+	}
 }`,
     },
     {
@@ -132,21 +132,21 @@ ruleTester.run('sort-collections', rule, {
       filename: 'package.json',
       output: `{
 	"scripts": {
-    "preinstall": "echo test",
-    "postinstall": "echo test"
-  }
+		"preinstall": "echo test",
+		"postinstall": "echo test"
+	}
 }`,
     },
     {
       code: `{
-	"exports": {
-		"./package.json": "./package.json",
-		".": {
-			"import": "./index.mjs",
-			"require": "./index.js",
-			"types": "./index.d.ts"
-		}
-	}
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./index.mjs",
+      "require": "./index.js",
+      "types": "./index.d.ts"
+    }
+  }
 }`,
       errors: [
         {
@@ -156,7 +156,7 @@ ruleTester.run('sort-collections', rule, {
       ],
       filename: 'package.json',
       output: `{
-	"exports": {
+  "exports": {
     ".": {
       "import": "./index.mjs",
       "require": "./index.js",
@@ -186,22 +186,22 @@ ruleTester.run('sort-collections', rule, {
       output: `{
 	"pnpm": {
 		"patchedDependencies": {
-    "eslint-plugin-package-json@0.31.0": "patches/eslint-plugin-package-json@0.31.0.patch",
-    "typescript@4.8.4": "patches/typescript@4.8.4.patch"
-  }
+			"eslint-plugin-package-json@0.31.0": "patches/eslint-plugin-package-json@0.31.0.patch",
+			"typescript@4.8.4": "patches/typescript@4.8.4.patch"
+		}
 	}
 }`,
     },
     {
       code: `{
-	"pnpm": {
-		"peerDependencyRules": {
-            "allowedVersions": {
-                "vue": "2",
-                "react": "17"
-            }
-		}
-	}
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "vue": "2",
+        "react": "17"
+      }
+    }
+  }
 }`,
       errors: [
         {
@@ -212,23 +212,22 @@ ruleTester.run('sort-collections', rule, {
       filename: 'package.json',
       options: [['pnpm.peerDependencyRules.allowedVersions']],
       output: `{
-	"pnpm": {
-		"peerDependencyRules": {
-            "allowedVersions": {
-    "react": "17",
-    "vue": "2"
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "react": "17",
+        "vue": "2"
+      }
+    }
   }
-		}
-	}
 }`,
     },
-    // custom order: listed keys follow the specified order
     {
       code: `{
-	"nx": {
-		"affected": {},
-		"npmScope": "test"
-	}
+  "nx": {
+    "affected": {},
+    "npmScope": "test"
+  }
 }`,
       errors: [
         {
@@ -240,13 +239,12 @@ ruleTester.run('sort-collections', rule, {
       name: 'custom order: listed keys follow the specified order',
       options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
       output: `{
-	"nx": {
+  "nx": {
     "npmScope": "test",
     "affected": {}
   }
 }`,
     },
-    // custom order: unlisted keys appended in lexicographical order
     {
       code: `{
 	"nx": {
@@ -266,14 +264,12 @@ ruleTester.run('sort-collections', rule, {
       options: [[{ key: 'nx', order: ['npmScope', 'affected'] }]],
       output: `{
 	"nx": {
-    "npmScope": "test",
-    "affected": {},
-    "workspaceLayout": {}
-  }
+		"npmScope": "test",
+		"affected": {},
+		"workspaceLayout": {}
+	}
 }`,
     },
-    // custom order on `scripts`: listed keys come first, unlisted keys fall
-    // back to lifecycle-aware order (not lexicographical)
     {
       code: `{
 	"scripts": {
@@ -294,11 +290,11 @@ ruleTester.run('sort-collections', rule, {
       options: [[{ key: 'scripts', order: ['watch'] }]],
       output: `{
 	"scripts": {
-    "watch": "echo watch",
-    "prebuild": "echo prebuild",
-    "build": "echo build",
-    "postbuild": "echo postbuild"
-  }
+		"watch": "echo watch",
+		"prebuild": "echo prebuild",
+		"build": "echo build",
+		"postbuild": "echo postbuild"
+	}
 }`,
     },
   ],

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -1,4 +1,4 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 import { isJSONStringLiteral } from './predicates.ts';
@@ -51,7 +51,7 @@ export const createSimpleRequirePropertyRule = (
 
       return {
         'Program > JSONExpressionStatement > JSONObjectExpression'(
-          node: JsonAST.JSONObjectExpression,
+          node: AST.JSONObjectExpression,
         ) {
           if (
             ignorePrivate &&

--- a/src/utils/createSimpleValidPropertyRule.ts
+++ b/src/utils/createSimpleValidPropertyRule.ts
@@ -1,4 +1,4 @@
-import type { AST as JsonAST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 import type { Result } from 'package-json-validator';
 
 import { createRule } from '../createRule.ts';
@@ -21,7 +21,7 @@ export const createSimpleValidPropertyRule = (
   const propertyNames = [propertyName, ...aliases];
   const rule = createRule({
     create(context) {
-      const reportIssues = (result: Result, node: JsonAST.JSONNode) => {
+      const reportIssues = (result: Result, node: AST.JSONNode) => {
         // Early return if there are no errors
         if (result.errorMessages.length === 0) {
           return;
@@ -64,11 +64,11 @@ export const createSimpleValidPropertyRule = (
       };
 
       return propertyNames.reduce<
-        Record<string, (node: JsonAST.JSONProperty) => void>
+        Record<string, (node: AST.JSONProperty) => void>
       >((acc, name) => {
         acc[
           `Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=${name}]`
-        ] = (node: JsonAST.JSONProperty) => {
+        ] = (node: AST.JSONProperty) => {
           const valueNode = node.value;
           const value: unknown = JSON.parse(
             context.sourceCode.getText(valueNode),


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1937 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change updates the logic of `sort-collections`' fixer to do more to detect indent character, indent depth, and newline characters based on the original state of the file, in order to use it for the fixer replacement.  The net net, is that the replacement should be more aligned with the code that it replaced and lean less on post-linting formatters.
