### PR TITLE
feat(require-author): add fixer to fill in `author` with git data

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This group of rules allows you to require that the associated top-level property
 
 | Name                                                                                                                         | Description                                                 | 💼    | 🔧  | 💡  |
 | :--------------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------- | :---- | :-- | :-- |
-| [require-author](https://eslint-plugin-package-json.dev/rules/require-properties/require-author)                             | Requires the `author` property to be present.               |       |     |     |
+| [require-author](https://eslint-plugin-package-json.dev/rules/require-properties/require-author)                             | Requires the `author` property to be present.               |       | 🔧  |     |
 | [require-bin](https://eslint-plugin-package-json.dev/rules/require-properties/require-bin)                                   | Requires the `bin` property to be present.                  |       |     |     |
 | [require-browser](https://eslint-plugin-package-json.dev/rules/require-properties/require-browser)                           | Requires the `browser` property to be present.              |       |     |     |
 | [require-bugs](https://eslint-plugin-package-json.dev/rules/require-properties/require-bugs)                                 | Requires the `bugs` property to be present.                 |       |     |     |

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -100,13 +100,14 @@ export default defineConfig(
     files: ['**/*.json', '**/*.jsonc'],
   },
   {
-    extends: [packageJson.configs['recommended-publishable']],
+    extends: [packageJson.configs.recommended, packageJson.configs.stylistic],
     files: ['package.json'],
     plugins: {
       'node-dependencies': nodeDependencies,
     },
     rules: {
       'node-dependencies/no-deprecated': ['error', { devDependencies: true }],
+      'package-json/require-author': 'error',
     },
   },
   {

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -107,7 +107,6 @@ export default defineConfig(
     },
     rules: {
       'node-dependencies/no-deprecated': ['error', { devDependencies: true }],
-      'package-json/require-author': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,6 @@
     "url": "git+https://github.com/michaelfaith/eslint-plugin-package-json.git"
   },
   "license": "MIT",
-  "author": {
-    "name": "michael faith",
-    "email": "michaelfaith@users.noreply.github.com"
-  },
   "contributors": [
     {
       "name": "James Zetlen",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
     "url": "git+https://github.com/michaelfaith/eslint-plugin-package-json.git"
   },
   "license": "MIT",
+  "author": {
+    "name": "michael faith",
+    "email": "michaelfaith@users.noreply.github.com"
+  },
   "contributors": [
     {
       "name": "James Zetlen",

--- a/site/src/content/docs/rule-list.md
+++ b/site/src/content/docs/rule-list.md
@@ -42,7 +42,7 @@ This group of rules allows you to require that the associated top-level property
 
 | Name                                                                                   | Description                                                 | 💼   | 🔧 | 💡 |
 | :------------------------------------------------------------------------------------- | :---------------------------------------------------------- | :--- | :- | :- |
-| [require-author](/rules/require-properties/require-author)                             | Requires the `author` property to be present.               |      |    |    |
+| [require-author](/rules/require-properties/require-author)                             | Requires the `author` property to be present.               |      | 🔧 |    |
 | [require-bin](/rules/require-properties/require-bin)                                   | Requires the `bin` property to be present.                  |      |    |    |
 | [require-browser](/rules/require-properties/require-browser)                           | Requires the `browser` property to be present.              |      |    |    |
 | [require-bugs](/rules/require-properties/require-bugs)                                 | Requires the `bugs` property to be present.                 |      |    |    |

--- a/site/src/content/docs/rules/require-properties/require-author.mdx
+++ b/site/src/content/docs/rules/require-properties/require-author.mdx
@@ -117,7 +117,7 @@ Example of **correct** code for this rule with the `{ "ignorePrivate": true }` o
 This rule is automatically fixable and will create a new `author` property, when it's missing.
 The `author` will have `name` and `email`, populated by data from `git config`.
 If the calls to `git config` fail, the fixer won't make the change.
-In order to be more performant in mono-repos, the author values retrieved from `git config` will be cached at the module level will be reused across multiple runs.
+In order to be more performant in monorepos, the `author` values retrieved from `git config` will be cached at the module level and will be reused across multiple runs.
 
 ## Related Rules
 

--- a/site/src/content/docs/rules/require-properties/require-author.mdx
+++ b/site/src/content/docs/rules/require-properties/require-author.mdx
@@ -3,6 +3,8 @@ title: 'require-author'
 description: 'Requires the `author` property to be present.'
 ---
 
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 {/* end auto-generated rule header */}
 
 import { Aside, TabItem, Tabs } from '@astrojs/starlight/components';
@@ -109,6 +111,13 @@ Example of **correct** code for this rule with the `{ "ignorePrivate": true }` o
 
 </TabItem>
 </Tabs>
+
+## Fixing
+
+This is automatically fixable and will create a new `author` property, when it's missing.
+The `author` will have `name` and `email`, populated by data from `git config`.
+If the calls to `git config` fail, the fixer won't make the change.
+In order to be more performant in mono-repos, the author values retrieved from `git config` will be cached at the module level will be reused across multiple runs.
 
 ## Related Rules
 

--- a/site/src/content/docs/rules/require-properties/require-author.mdx
+++ b/site/src/content/docs/rules/require-properties/require-author.mdx
@@ -114,7 +114,7 @@ Example of **correct** code for this rule with the `{ "ignorePrivate": true }` o
 
 ## Fixing
 
-This is automatically fixable and will create a new `author` property, when it's missing.
+This rule is automatically fixable and will create a new `author` property, when it's missing.
 The `author` will have `name` and `email`, populated by data from `git config`.
 If the calls to `git config` fail, the fixer won't make the change.
 In order to be more performant in mono-repos, the author values retrieved from `git config` will be cached at the module level will be reused across multiple runs.

--- a/site/src/content/docs/rules/require-properties/require-private.mdx
+++ b/site/src/content/docs/rules/require-properties/require-private.mdx
@@ -37,6 +37,10 @@ This rule checks for the existence of the `private` property and reports a viola
 </TabItem>
 </Tabs>
 
+## Fixing
+
+This is automatically fixable and will add a `private` property, if one is missing, with the value `false`, which is how your package manager was treating the package when no property was present.
+
 ## Related Rules
 
 - [`valid-private`](/rules/valid-properties/valid-private) - Enforces that the `private` property is valid.

--- a/site/src/content/docs/rules/require-properties/require-private.mdx
+++ b/site/src/content/docs/rules/require-properties/require-private.mdx
@@ -39,7 +39,7 @@ This rule checks for the existence of the `private` property and reports a viola
 
 ## Fixing
 
-This is automatically fixable and will add a `private` property, if one is missing, with the value `false`, which is how your package manager was treating the package when no property was present.
+This rule is automatically fixable and will add a `private` property, if one is missing, with the value `false`, which is how your package manager was treating the package when no property was present.
 
 ## Related Rules
 

--- a/site/src/content/docs/rules/require-properties/require-type.mdx
+++ b/site/src/content/docs/rules/require-properties/require-type.mdx
@@ -108,6 +108,10 @@ Example of **correct** code for this rule with the `{ "ignorePrivate": true }` o
 </TabItem>
 </Tabs>
 
+## Fixing
+
+This is automatically fixable and will add a `type` property, if one is missing, with the value `"commonjs"`, which is how Node was treating the package, when no property was present.
+
 ## Related Rules
 
 - [`valid-type`](/rules/valid-properties/valid-type) - Enforces that the `type` property is valid.

--- a/site/src/content/docs/rules/require-properties/require-type.mdx
+++ b/site/src/content/docs/rules/require-properties/require-type.mdx
@@ -110,7 +110,7 @@ Example of **correct** code for this rule with the `{ "ignorePrivate": true }` o
 
 ## Fixing
 
-This is automatically fixable and will add a `type` property, if one is missing, with the value `"commonjs"`, which is how Node was treating the package, when no property was present.
+This rule is automatically fixable and will add a `type` property, if one is missing, with the value `"commonjs"`, which is how Node was treating the package, when no property was present.
 
 ## Related Rules
 

--- a/src/rules/require-properties.ts
+++ b/src/rules/require-properties.ts
@@ -2,12 +2,18 @@ import {
   createSimpleRequirePropertyRule,
   type CreateRequirePropertyRuleOptions,
 } from '../utils/createSimpleRequirePropertyRule.js';
+import { getGitAuthor } from '../utils/git/getGitAuthor.ts';
 
 export const propertyConfig: [
   name: string,
   options?: CreateRequirePropertyRuleOptions,
 ][] = [
-  ['author'],
+  [
+    'author',
+    {
+      fixValue: getGitAuthor,
+    },
+  ],
   ['bin'],
   ['browser'],
   ['bugs', { ignorePrivateDefault: true }],

--- a/src/tests/rules/require-properties.test.ts
+++ b/src/tests/rules/require-properties.test.ts
@@ -17,9 +17,7 @@ for (const ruleName of ruleNames) {
     typeof rawFixValue === 'function' ? rawFixValue() : rawFixValue;
 
   const emitOutputIfFixable = (expectedOutput: string) =>
-    fixValue === undefined || fixValue === null
-      ? {}
-      : { output: expectedOutput };
+    fixValue === undefined ? {} : { output: expectedOutput };
 
   ruleTester.run(ruleName, rules[ruleName], {
     invalid: [

--- a/src/tests/rules/require-properties.test.ts
+++ b/src/tests/rules/require-properties.test.ts
@@ -10,10 +10,16 @@ for (const ruleName of ruleNames) {
   const propertyOptions = propertyConfig.find(
     ([name]) => name === propertyName,
   )?.[1];
-  const fixValue = propertyOptions?.fixValue;
+  const rawFixValue = propertyOptions?.fixValue;
+
+  const fixValue =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+    typeof rawFixValue === 'function' ? rawFixValue() : rawFixValue;
 
   const emitOutputIfFixable = (expectedOutput: string) =>
-    fixValue === undefined ? {} : { output: expectedOutput };
+    fixValue === undefined || fixValue === null
+      ? {}
+      : { output: expectedOutput };
 
   ruleTester.run(ruleName, rules[ruleName], {
     invalid: [

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -75,10 +75,9 @@ export const createSimpleRequirePropertyRule = (
                 ),
             )
           ) {
-            let resolvedValue = fixValue;
-            if (typeof fixValue === 'function') {
-              resolvedValue = fixValue();
-            }
+            const resolvedValue: unknown =
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+              typeof fixValue === 'function' ? fixValue() : fixValue;
             context.report({
               data: { property: propertyName },
               fix:

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -81,9 +81,13 @@ export const createSimpleRequirePropertyRule = (
                 fixValue === undefined
                   ? undefined
                   : function* (fixer) {
+                      let resolvedValue = fixValue;
+                      if (typeof fixValue === 'function') {
+                        resolvedValue = fixValue();
+                      }
                       yield fixer.insertTextAfterRange(
                         [0, 1],
-                        `\n  "${propertyName}": ${JSON.stringify(fixValue)}`,
+                        `\n  "${propertyName}": ${JSON.stringify(resolvedValue)}`,
                       );
                       yield node.properties.length > 0
                         ? fixer.insertTextAfterRange([0, 1], ',')

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -75,16 +75,16 @@ export const createSimpleRequirePropertyRule = (
                 ),
             )
           ) {
+            let resolvedValue = fixValue;
+            if (typeof fixValue === 'function') {
+              resolvedValue = fixValue();
+            }
             context.report({
               data: { property: propertyName },
               fix:
-                fixValue === undefined
+                resolvedValue === undefined
                   ? undefined
                   : function* (fixer) {
-                      let resolvedValue = fixValue;
-                      if (typeof fixValue === 'function') {
-                        resolvedValue = fixValue();
-                      }
                       yield fixer.insertTextAfterRange(
                         [0, 1],
                         `\n  "${propertyName}": ${JSON.stringify(resolvedValue)}`,

--- a/src/utils/git/getGitAuthor.test.ts
+++ b/src/utils/git/getGitAuthor.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileSync = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFileSync,
+}));
+
+const importGetGitAuthor = async () => await import('./getGitAuthor.ts');
+
+describe('getGitAuthor', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    execFileSync.mockReset();
+  });
+
+  it('should return author name and email from git config output', async () => {
+    execFileSync
+      .mockReturnValueOnce(' Jane Doe \n')
+      .mockReturnValueOnce(' jane@example.com \n');
+
+    const { getGitAuthor } = await importGetGitAuthor();
+
+    expect(getGitAuthor()).toEqual({
+      email: 'jane@example.com',
+      name: 'Jane Doe',
+    });
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['config', '--get', 'user.name'],
+      { encoding: 'utf8' },
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'git',
+      ['config', '--get', 'user.email'],
+      { encoding: 'utf8' },
+    );
+  });
+
+  it('should cache the resolved author and does not call git again on subsequent calls', async () => {
+    execFileSync
+      .mockReturnValueOnce(' Jane Doe \n')
+      .mockReturnValueOnce(' jane@example.com \n');
+
+    const { getGitAuthor } = await importGetGitAuthor();
+
+    expect(getGitAuthor()).toEqual({
+      email: 'jane@example.com',
+      name: 'Jane Doe',
+    });
+    expect(getGitAuthor()).toEqual({
+      email: 'jane@example.com',
+      name: 'Jane Doe',
+    });
+    expect(execFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('should return undefined when git config commands fail', async () => {
+    execFileSync.mockImplementation(() => {
+      throw new Error('git config failed');
+    });
+
+    const { getGitAuthor } = await importGetGitAuthor();
+
+    expect(getGitAuthor()).toBeUndefined();
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('should no longer try to call git if git config fails and returns undefined on subsequent calls', async () => {
+    execFileSync.mockImplementation(() => {
+      throw new Error('git config failed');
+    });
+
+    const { getGitAuthor } = await importGetGitAuthor();
+
+    expect(getGitAuthor()).toBeUndefined();
+    expect(getGitAuthor()).toBeUndefined();
+    expect(execFileSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/git/getGitAuthor.ts
+++ b/src/utils/git/getGitAuthor.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from 'node:child_process';
+
+interface Author {
+  email: string;
+  name: string;
+}
+
+let cachedAuthor: Author | null | undefined;
+
+export const getGitAuthor = (): Author | undefined => {
+  if (cachedAuthor === null) {
+    return undefined;
+  } else if (cachedAuthor !== undefined) {
+    return cachedAuthor;
+  }
+
+  try {
+    const name = execFileSync('git', ['config', '--get', 'user.name'], {
+      encoding: 'utf8',
+    }).trim();
+
+    const email = execFileSync('git', ['config', '--get', 'user.email'], {
+      encoding: 'utf8',
+    }).trim();
+
+    cachedAuthor = {
+      name,
+      // eslint-disable-next-line perfectionist/sort-objects
+      email,
+    };
+  } catch {
+    cachedAuthor = null;
+    return undefined;
+  }
+
+  return cachedAuthor;
+};

--- a/src/utils/git/index.ts
+++ b/src/utils/git/index.ts
@@ -1,0 +1,1 @@
+export { getGitAuthor } from './getGitAuthor.ts';


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1950
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new fixer for both `require-author` and `valid-author`, to fill in the `author` field when missing (`require-author`) or present but populated with the wrong data type (`valid-author`).
