### PR TITLE
feat(valid-author): add fixer for replacing empty or invalid `author`

### DIFF
--- a/.eslint-doc-generatorrc.js
+++ b/.eslint-doc-generatorrc.js
@@ -1,7 +1,18 @@
 import prettier from 'prettier';
 
-import { rules as requireRules } from './lib/rules/require-properties.mjs';
-import { rules as validRules } from './lib/rules/valid-properties.mjs';
+import { rules } from './lib/index.mjs';
+
+const ruleEntries = Object.entries(rules);
+const requireRules = Object.fromEntries(
+  ruleEntries.filter(
+    ([, rule]) => rule.meta.docs.ruleGroup === 'require-properties',
+  ),
+);
+const validRules = Object.fromEntries(
+  ruleEntries.filter(
+    ([, rule]) => rule.meta.docs.ruleGroup === 'valid-properties',
+  ),
+);
 
 const requireRuleNames = Object.keys(requireRules);
 const validRuleNames = Object.keys(validRules);

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ This group of rules allows you to enforce that the value of the associated top-l
 
 | Name                                                                                                                   | Description                                                                           | 💼    | 🔧  | 💡  |
 | :--------------------------------------------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :---- | :-- | :-- |
-| [valid-author](https://eslint-plugin-package-json.dev/rules/valid-properties/valid-author)                             | Enforce that the `author` property is valid.                                          | ✅ 📦 |     |     |
+| [valid-author](https://eslint-plugin-package-json.dev/rules/valid-properties/valid-author)                             | Enforce that the `author` property is valid.                                          | ✅ 📦 | 🔧  |     |
 | [valid-bin](https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bin)                                   | Enforce that the `bin` property is valid.                                             | ✅ 📦 |     |     |
 | [valid-browser](https://eslint-plugin-package-json.dev/rules/valid-properties/valid-browser)                           | Enforce that the `browser` property is valid.                                         | ✅ 📦 |     |     |
 | [valid-bugs](https://eslint-plugin-package-json.dev/rules/valid-properties/valid-bugs)                                 | Enforce that the `bugs` property is valid.                                            | ✅ 📦 |     |     |

--- a/site/src/content/docs/rule-list.md
+++ b/site/src/content/docs/rule-list.md
@@ -88,7 +88,7 @@ This group of rules allows you to enforce that the value of the associated top-l
 
 | Name                                                                             | Description                                                                           | 💼   | 🔧 | 💡 |
 | :------------------------------------------------------------------------------- | :------------------------------------------------------------------------------------ | :--- | :- | :- |
-| [valid-author](/rules/valid-properties/valid-author)                             | Enforce that the `author` property is valid.                                          | ✅ 📦 |    |    |
+| [valid-author](/rules/valid-properties/valid-author)                             | Enforce that the `author` property is valid.                                          | ✅ 📦 | 🔧 |    |
 | [valid-bin](/rules/valid-properties/valid-bin)                                   | Enforce that the `bin` property is valid.                                             | ✅ 📦 |    |    |
 | [valid-browser](/rules/valid-properties/valid-browser)                           | Enforce that the `browser` property is valid.                                         | ✅ 📦 |    |    |
 | [valid-bugs](/rules/valid-properties/valid-bugs)                                 | Enforce that the `bugs` property is valid.                                            | ✅ 📦 |    |    |

--- a/site/src/content/docs/rules/valid-properties/valid-author.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-author.mdx
@@ -129,6 +129,14 @@ The field can be either a string or an object with `name` and optionally `email`
 </TabItem>
 </Tabs>
 
+## Fixing
+
+This rule is automatically fixable.
+It will replace an empty `author` string, or `author` values that are of the wrong type, with a value that has `name and `email`, populated by data from `git config`.
+Furthermore, if `author`*is* the correct type, but is missing`name`or the`name`or`email`are empty, the fixer will populate those values with data from`git config`as well.
+If the calls to`git config`fail, the fixer won't make the change.
+In order to be more performant in monorepos, the`author`values retrieved from`git config` will be cached at the module level and will be reused across multiple runs.
+
 ## Related Rules
 
 - [`require-author`](/rules/require-properties/require-author) - Enforces that the `author` property is present.

--- a/site/src/content/docs/rules/valid-properties/valid-author.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-author.mdx
@@ -134,10 +134,10 @@ The field can be either a string or an object with `name` and optionally `email`
 ## Fixing
 
 This rule is automatically fixable.
-It will replace an empty `author` string, or `author` values that are of the wrong type, with a value that has `name and `email`, populated by data from `git config`.
-Furthermore, if `author`*is* the correct type, but is missing`name`or the`name`or`email`are empty, the fixer will populate those values with data from`git config`as well.
-If the calls to`git config`fail, the fixer won't make the change.
-In order to be more performant in monorepos, the`author`values retrieved from`git config` will be cached at the module level and will be reused across multiple runs.
+It will replace an empty `author` string, or `author` values that are of the wrong type, with a value that has `name` and `email`, populated by data from `git config`.
+Furthermore, if `author` _is_ the correct type, but is missing `name` or the `name` or `email` are empty, the fixer will populate those values with data from `git config`as well.
+If the calls to `git config` fail, the fixer won't make the change.
+In order to be more performant in monorepos, the `author` values retrieved from `git config` will be cached at the module level and will be reused across multiple runs.
 
 ## Related Rules
 

--- a/site/src/content/docs/rules/valid-properties/valid-author.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-author.mdx
@@ -135,7 +135,7 @@ The field can be either a string or an object with `name` and optionally `email`
 
 This rule is automatically fixable.
 It will replace an empty `author` string, or `author` values that are of the wrong type, with a value that has `name` and `email`, populated by data from `git config`.
-Furthermore, if `author` _is_ the correct type, but is missing `name` or the `name` or `email` are empty, the fixer will populate those values with data from `git config`as well.
+Furthermore, if `author` _is_ the correct type, but is missing `name` or the `name` or `email` are empty, the fixer will populate those values with data from `git config` as well.
 If the calls to `git config` fail, the fixer won't make the change.
 In order to be more performant in monorepos, the `author` values retrieved from `git config` will be cached at the module level and will be reused across multiple runs.
 

--- a/site/src/content/docs/rules/valid-properties/valid-author.mdx
+++ b/site/src/content/docs/rules/valid-properties/valid-author.mdx
@@ -5,6 +5,8 @@ description: 'Enforce that the `author` property is valid.'
 
 💼 This rule is enabled in the following configs: ✅ `recommended`, 📦 `recommended-publishable`.
 
+🔧 This rule is automatically fixable by the [`--fix` CLI option](https://eslint.org/docs/latest/user-guide/command-line-interface#--fix).
+
 {/* end auto-generated rule header */}
 
 import { TabItem, Tabs } from '@astrojs/starlight/components';

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -21,6 +21,7 @@ import { rule as scriptsNameCasing } from './rules/scripts-name-casing.ts';
 import { rule as sortCollections } from './rules/sort-collections.ts';
 import { rule as specifyPeersLocally } from './rules/specify-peers-locally.ts';
 import { rule as uniqueDependencies } from './rules/unique-dependencies.ts';
+import { rule as validAuthor } from './rules/valid-author.ts';
 import { rule as validPeerDependenciesMetaRelationship } from './rules/valid-peerDependenciesMeta-relationship.ts';
 import { rules as basicValidRules } from './rules/valid-properties.ts';
 import { rule as validRepositoryDirectory } from './rules/valid-repository-directory.ts';
@@ -45,6 +46,7 @@ const rules: Record<string, PackageJsonRuleModule> = {
   'sort-collections': sortCollections,
   'specify-peers-locally': specifyPeersLocally,
   'unique-dependencies': uniqueDependencies,
+  'valid-author': validAuthor,
   ...basicValidRules,
   'valid-peerDependenciesMeta-relationship':
     validPeerDependenciesMetaRelationship,

--- a/src/rules/valid-author.ts
+++ b/src/rules/valid-author.ts
@@ -1,0 +1,123 @@
+import type { Rule } from 'eslint';
+import type { AST } from 'jsonc-eslint-parser';
+import { validateAuthor, type Result } from 'package-json-validator';
+
+import { createRule } from '../createRule.ts';
+import { getGitAuthor } from '../utils/git/index.ts';
+import { isJSONStringLiteral } from '../utils/predicates/isJSONStringLiteral.ts';
+
+export const rule = createRule({
+  create(context) {
+    const createFixer = (
+      propertyName: string,
+      node: AST.JSONNode,
+    ): Rule.ReportFixer | undefined => {
+      const author = getGitAuthor();
+      if (!author) {
+        return undefined;
+      }
+      let mergedAuthor = author;
+      const originalValue: unknown = JSON.parse(
+        context.sourceCode.getText(node),
+      );
+      if (
+        originalValue &&
+        typeof originalValue === 'object' &&
+        !Array.isArray(originalValue)
+      ) {
+        mergedAuthor = { name: author.name, ...originalValue };
+      }
+
+      switch (propertyName) {
+        case 'author':
+          return (fixer) =>
+            fixer.replaceText(
+              node,
+              JSON.stringify(mergedAuthor, null, 2).split('\n').join('\n  '),
+            );
+        case 'email':
+          return (fixer) =>
+            fixer.replaceText(node, JSON.stringify(author.email));
+        case 'name':
+          return (fixer) =>
+            fixer.replaceText(node, JSON.stringify(author.name));
+        default:
+          return undefined;
+      }
+    };
+
+    const reportIssues = (
+      result: Result,
+      node: AST.JSONExpression,
+      propertyName?: string,
+    ) => {
+      // Early return if there are no errors
+      if (result.errorMessages.length === 0) {
+        return;
+      }
+
+      if (result.issues.length) {
+        for (const issue of result.issues) {
+          context.report({
+            data: {
+              error: issue.message,
+            },
+            fix:
+              propertyName === undefined
+                ? undefined
+                : createFixer(propertyName, node),
+            messageId: 'validationError',
+            node,
+          });
+        }
+      }
+
+      const childrenWithIssues = result.childResults.filter(
+        (childResult) => childResult.errorMessages.length,
+      );
+      // If the value is an object, and has child results with issues, then report those too
+      if (node.type === 'JSONObjectExpression' && childrenWithIssues.length) {
+        for (const childResult of childrenWithIssues) {
+          const childNode = node.properties[childResult.index];
+          const childPropertyName = childNode.key;
+          reportIssues(
+            childResult,
+            childNode.value,
+            isJSONStringLiteral(childPropertyName)
+              ? childPropertyName.value
+              : undefined,
+          );
+        }
+      }
+    };
+
+    return {
+      'Program > JSONExpressionStatement > JSONObjectExpression > JSONProperty[key.value=author]'(
+        node: AST.JSONProperty,
+      ) {
+        const valueNode = node.value;
+        const value: unknown = JSON.parse(
+          context.sourceCode.getText(valueNode),
+        );
+
+        const result = validateAuthor(value);
+        reportIssues(result, valueNode, 'author');
+      },
+    };
+  },
+  meta: {
+    docs: {
+      category: 'Best Practices',
+      description: 'Enforce that the `author` property is valid.',
+      recommended: true,
+      ruleGroup: 'valid-properties',
+    },
+    fixable: 'code',
+    messages: {
+      validationError: `Invalid author: {{ error }}`,
+    },
+    schema: [],
+    type: 'problem',
+  },
+  name: 'valid-author',
+});

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -1,5 +1,4 @@
 import {
-  validateAuthor,
   validateBin,
   validateBrowser,
   validateBugs,
@@ -49,7 +48,6 @@ interface ValidPropertyOptions {
 // List of all properties we want to create valid- rules for,
 // in the format [propertyName, validationFunction | validPropertyOptions]
 const properties = [
-  ['author', validateAuthor],
   ['bin', validateBin],
   ['browser', validateBrowser],
   ['bugs', validateBugs],

--- a/src/tests/rules/require-properties.test.ts
+++ b/src/tests/rules/require-properties.test.ts
@@ -16,6 +16,11 @@ for (const ruleName of ruleNames) {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-call
     typeof rawFixValue === 'function' ? rawFixValue() : rawFixValue;
 
+  const replacementString =
+    fixValue === undefined
+      ? 'undefined'
+      : JSON.stringify(fixValue, null, 2).split('\n').join('\n  ');
+
   const emitOutputIfFixable = (expectedOutput: string) =>
     fixValue === undefined ? {} : { output: expectedOutput };
 
@@ -34,7 +39,7 @@ for (const ruleName of ruleNames) {
         ],
         name: 'empty object',
         ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)}
+  "${propertyName}": ${replacementString}
 }`),
       },
       {
@@ -53,7 +58,7 @@ for (const ruleName of ruleNames) {
         ],
         name: 'missing property',
         ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "foo": "bar",
   "baz": "1.0.0"
 }`),
@@ -77,7 +82,7 @@ for (const ruleName of ruleNames) {
         ],
         name: 'nested property only',
         ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "foo": "bar",
   "baz": "1.0.0",
   "bat": {
@@ -103,7 +108,7 @@ for (const ruleName of ruleNames) {
               ],
               name: 'missing property with private: true > enforceForPrivate: true',
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": true
 }`),
               settings: {
@@ -127,7 +132,7 @@ for (const ruleName of ruleNames) {
               ],
               name: 'missing property with private: false > enforceForPrivate: false',
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": false
 }`),
               settings: {
@@ -152,7 +157,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: true > ignorePrivate: false',
               options: [{ ignorePrivate: false }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": true
 }`),
             },
@@ -172,7 +177,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: false > ignorePrivate: true',
               options: [{ ignorePrivate: true }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": false
 }`),
             },
@@ -192,7 +197,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: true > ignorePrivate: true',
               options: [{ ignorePrivate: true }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": "true"
 }`),
             },
@@ -210,7 +215,7 @@ for (const ruleName of ruleNames) {
               name: 'empty object > ignorePrivate: true',
               options: [{ ignorePrivate: true }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)}
+  "${propertyName}": ${replacementString}
 }`),
             },
             {
@@ -229,7 +234,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: true > ignorePrivate: false, enforceForPrivate: true',
               options: [{ ignorePrivate: false }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": true
 }`),
               settings: {
@@ -254,7 +259,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: false > ignorePrivate: true, enforceForPrivate: true',
               options: [{ ignorePrivate: true }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": false
 }`),
               settings: {
@@ -277,7 +282,7 @@ for (const ruleName of ruleNames) {
               name: 'empty object > ignorePrivate: true, enforceForPrivate: true',
               options: [{ ignorePrivate: true }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)}
+  "${propertyName}": ${replacementString}
 }`),
               settings: {
                 packageJson: {
@@ -301,7 +306,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: true > ignorePrivate: false, enforceForPrivate: false',
               options: [{ ignorePrivate: false }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": true
 }`),
               settings: {
@@ -326,7 +331,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: false > ignorePrivate: false, enforceForPrivate: false',
               options: [{ ignorePrivate: false }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": false
 }`),
               settings: {
@@ -351,7 +356,7 @@ for (const ruleName of ruleNames) {
               name: 'missing property with private: false > ignorePrivate: true, enforceForPrivate: false',
               options: [{ ignorePrivate: true }],
               ...emitOutputIfFixable(`{
-  "${propertyName}": ${JSON.stringify(fixValue)},
+  "${propertyName}": ${replacementString},
   "private": false
 }`),
               settings: {

--- a/src/tests/rules/valid-author.test.ts
+++ b/src/tests/rules/valid-author.test.ts
@@ -1,9 +1,19 @@
-import { rules } from '../../rules/valid-properties.ts';
+import { vi } from 'vitest';
+
+import { rule } from '../../rules/valid-author.ts';
 import { ruleTester } from './ruleTester.ts';
 
-const ruleName = 'valid-author';
+const mockAuthor = {
+  name: 'michael faith',
+  // eslint-disable-next-line perfectionist/sort-objects
+  email: 'mfaith@github.com',
+};
 
-ruleTester.run(ruleName, rules[ruleName], {
+vi.mock('../../utils/git/index.ts', () => ({
+  getGitAuthor: () => mockAuthor,
+}));
+
+ruleTester.run('valid-author', rule, {
   invalid: [
     {
       code: `{
@@ -20,6 +30,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -36,6 +52,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -52,6 +74,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -68,6 +96,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -83,6 +117,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -98,6 +138,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -113,6 +159,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -128,6 +180,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -143,6 +201,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -159,6 +223,11 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith"
+  }
+}`,
     },
     {
       code: `{
@@ -177,6 +246,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "john@example.com"
+  }
+}`,
     },
     {
       code: `{
@@ -194,6 +269,11 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith"
+  }
+}`,
     },
     {
       code: `{
@@ -211,6 +291,11 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith"
+  }
+}`,
     },
     {
       code: `{
@@ -229,6 +314,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "John",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
     {
       code: `{
@@ -269,6 +360,12 @@ ruleTester.run(ruleName, rules[ruleName], {
         },
       ],
       filename: 'package.json',
+      output: `{
+  "author": {
+    "name": "michael faith",
+    "email": "mfaith@github.com"
+  }
+}`,
     },
   ],
 

--- a/src/tests/rules/valid-author.test.ts
+++ b/src/tests/rules/valid-author.test.ts
@@ -1,414 +1,740 @@
-import { vi } from 'vitest';
+import { beforeEach, describe, vi } from 'vitest';
 
 import { rule } from '../../rules/valid-author.ts';
+import { getGitAuthor } from '../../utils/git/index.ts';
 import { ruleTester } from './ruleTester.ts';
 
-const mockAuthor = {
-  name: 'michael faith',
-  // eslint-disable-next-line perfectionist/sort-objects
-  email: 'mfaith@github.com',
-};
-
 vi.mock('../../utils/git/index.ts', () => ({
-  getGitAuthor: () => mockAuthor,
+  getGitAuthor: vi.fn(),
 }));
 
-ruleTester.run('valid-author', rule, {
-  invalid: [
-    {
-      code: `{
+describe('valid-author', () => {
+  describe('with git author returned', () => {
+    beforeEach(() => {
+      vi.mocked(getGitAuthor).mockReturnValue({
+        name: 'michael faith',
+        // eslint-disable-next-line perfectionist/sort-objects
+        email: 'mfaith@github.com',
+      });
+    });
+
+    ruleTester.run('valid-author', rule, {
+      invalid: [
+        {
+          code: `{
   "author": null
 }`,
-      errors: [
-        {
-          data: {
-            error:
-              'the type should be a `string` or an `object` with at least a `name` property',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": 123
 }`,
-      errors: [
-        {
-          data: {
-            error:
-              'the type should be a `string` or an `object` with at least a `name` property',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": true
 }`,
-      errors: [
-        {
-          data: {
-            error:
-              'the type should be a `string` or an `object` with at least a `name` property',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": []
 }`,
-      errors: [
-        {
-          data: {
-            error:
-              'the type should be a `string` or an `object` with at least a `name` property',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": ""
 }`,
-      errors: [
-        {
-          data: {
-            error: 'person should have a name',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'person should have a name',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": "   "
 }`,
-      errors: [
-        {
-          data: {
-            error: 'person should have a name',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'person should have a name',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": "John <invalid>"
 }`,
-      errors: [
-        {
-          data: {
-            error: 'email is not valid: invalid',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'email is not valid: invalid',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": "John (not-url)"
 }`,
-      errors: [
-        {
-          data: {
-            error: 'url is not valid: not-url',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'url is not valid: not-url',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": "<john@example.com>"
 }`,
-      errors: [
-        {
-          data: {
-            error: 'person should have a name',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'person should have a name',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": {}
 }`,
-      errors: [
-        {
-          data: {
-            error:
-              'the type should be a `string` or an `object` with at least a `name` property',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": {
     "email": "john@example.com"
   }
 }`,
-      errors: [
-        {
-          data: {
-            error:
-              'the type should be a `string` or an `object` with at least a `name` property',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "john@example.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": {
     "name": ""
   }
 }`,
-      errors: [
-        {
-          data: {
-            error: 'name should not be empty',
-          },
-          line: 3,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'name should not be empty',
+              },
+              line: 3,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": {
     "name": "    "
   }
 }`,
-      errors: [
-        {
-          data: {
-            error: 'name should not be empty',
-          },
-          line: 3,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'name should not be empty',
+              },
+              line: 3,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": {
     "name": "John",
     "email": "invalid"
   }
 }`,
-      errors: [
-        {
-          data: {
-            error: 'email is not valid: invalid',
-          },
-          line: 4,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'email is not valid: invalid',
+              },
+              line: 4,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "John",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-    {
-      code: `{
+        },
+        {
+          code: `{
   "author": {
     "name": "John",
     "url": "invalid"
   }
 }`,
-      errors: [
-        {
-          data: {
-            error: 'url is not valid: invalid',
-          },
-          line: 4,
-          messageId: 'validationError',
+          errors: [
+            {
+              data: {
+                error: 'url is not valid: invalid',
+              },
+              line: 4,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
         },
-      ],
-      filename: 'package.json',
-    },
-    {
-      code: `{
+        {
+          code: `{
   "author": "John <invalid-email> (invalid-url)"
 }`,
-      errors: [
-        {
-          data: {
-            error: 'email is not valid: invalid-email',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-        {
-          data: {
-            error: 'url is not valid: invalid-url',
-          },
-          line: 2,
-          messageId: 'validationError',
-        },
-      ],
-      filename: 'package.json',
-      output: `{
+          errors: [
+            {
+              data: {
+                error: 'email is not valid: invalid-email',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+            {
+              data: {
+                error: 'url is not valid: invalid-url',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+          output: `{
   "author": {
     "name": "michael faith",
     "email": "mfaith@github.com"
   }
 }`,
-    },
-  ],
+        },
+      ],
 
-  valid: [
-    {
-      code: `{}`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": "John Doe" }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": "John <john@example.com>" }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": "John (https://example.com)" }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": "John <john@example.com> (https://example.com)" }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": { "name": "John" } }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": { "name": "John", "email": "john@example.com" } }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": { "name": "John", "url": "https://example.com" } }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": { "name": "John", "email": "john@example.com", "url": "https://example.com" } }`,
-      filename: 'package.json',
-    },
-    {
-      code: `{ "author": null }`,
-      filename: 'not-a-package.json',
-    },
-  ],
+      valid: [
+        {
+          code: `{}`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John Doe" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John <john@example.com>" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John (https://example.com)" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John <john@example.com> (https://example.com)" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John", "email": "john@example.com" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John", "url": "https://example.com" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John", "email": "john@example.com", "url": "https://example.com" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": null }`,
+          filename: 'not-a-package.json',
+        },
+      ],
+    });
+  });
+
+  describe('without git author returned', () => {
+    beforeEach(() => {
+      vi.mocked(getGitAuthor).mockReturnValue(undefined);
+    });
+
+    ruleTester.run('valid-author', rule, {
+      invalid: [
+        {
+          code: `{
+  "author": null
+}`,
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": 123
+}`,
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": true
+}`,
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": []
+}`,
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": ""
+}`,
+          errors: [
+            {
+              data: {
+                error: 'person should have a name',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": "   "
+}`,
+          errors: [
+            {
+              data: {
+                error: 'person should have a name',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": "John <invalid>"
+}`,
+          errors: [
+            {
+              data: {
+                error: 'email is not valid: invalid',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": "John (not-url)"
+}`,
+          errors: [
+            {
+              data: {
+                error: 'url is not valid: not-url',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": "<john@example.com>"
+}`,
+          errors: [
+            {
+              data: {
+                error: 'person should have a name',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": {}
+}`,
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": {
+    "email": "john@example.com"
+  }
+}`,
+          errors: [
+            {
+              data: {
+                error:
+                  'the type should be a `string` or an `object` with at least a `name` property',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": {
+    "name": ""
+  }
+}`,
+          errors: [
+            {
+              data: {
+                error: 'name should not be empty',
+              },
+              line: 3,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": {
+    "name": "    "
+  }
+}`,
+          errors: [
+            {
+              data: {
+                error: 'name should not be empty',
+              },
+              line: 3,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": {
+    "name": "John",
+    "email": "invalid"
+  }
+}`,
+          errors: [
+            {
+              data: {
+                error: 'email is not valid: invalid',
+              },
+              line: 4,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": {
+    "name": "John",
+    "url": "invalid"
+  }
+}`,
+          errors: [
+            {
+              data: {
+                error: 'url is not valid: invalid',
+              },
+              line: 4,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+        {
+          code: `{
+  "author": "John <invalid-email> (invalid-url)"
+}`,
+          errors: [
+            {
+              data: {
+                error: 'email is not valid: invalid-email',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+            {
+              data: {
+                error: 'url is not valid: invalid-url',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
+          filename: 'package.json',
+        },
+      ],
+
+      valid: [
+        {
+          code: `{}`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John Doe" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John <john@example.com>" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John (https://example.com)" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": "John <john@example.com> (https://example.com)" }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John", "email": "john@example.com" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John", "url": "https://example.com" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": { "name": "John", "email": "john@example.com", "url": "https://example.com" } }`,
+          filename: 'package.json',
+        },
+        {
+          code: `{ "author": null }`,
+          filename: 'not-a-package.json',
+        },
+      ],
+    });
+  });
 });

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -86,7 +86,7 @@ export const createSimpleRequirePropertyRule = (
                   : function* (fixer) {
                       yield fixer.insertTextAfterRange(
                         [0, 1],
-                        `\n  "${propertyName}": ${JSON.stringify(resolvedValue)}`,
+                        `\n  "${propertyName}": ${JSON.stringify(resolvedValue, null, 2).split('\n').join('\n  ')}`,
                       );
                       yield node.properties.length > 0
                         ? fixer.insertTextAfterRange([0, 1], ',')

--- a/src/utils/createSimpleValidPropertyRule.ts
+++ b/src/utils/createSimpleValidPropertyRule.ts
@@ -3,6 +3,7 @@ import type { Result } from 'package-json-validator';
 
 import { createRule } from '../createRule.ts';
 
+// TODO: move this type upstream to `package-json-validator`
 export type ValidationFunction = (value: unknown) => Result;
 
 /**

--- a/src/utils/git/getGitAuthor.ts
+++ b/src/utils/git/getGitAuthor.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 
 interface Author {
-  email: string;
+  email?: string;
   name: string;
 }
 
@@ -25,8 +25,7 @@ export const getGitAuthor = (): Author | undefined => {
 
     cachedAuthor = {
       name,
-      // eslint-disable-next-line perfectionist/sort-objects
-      email,
+      ...(email && { email }),
     };
   } catch {
     cachedAuthor = null;


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1636
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds a new fixer for both `valid-author`, to fill in the `author` field when populated with the wrong data type or empty strings.
