### PR TITLE
docs: add `@astrojs/markdown-satteri` processor

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,4 @@
+import { satteri } from '@astrojs/markdown-satteri';
 import starlight from '@astrojs/starlight';
 import starlightCatppuccin from '@catppuccin/starlight';
 import { defineConfig } from 'astro/config';
@@ -48,6 +49,11 @@ export default defineConfig({
       title: 'ESLint Plugin: Package JSON',
     }),
   ],
+  markdown: {
+    processor: satteri({
+      features: { directive: true },
+    }),
+  },
   outDir: './dist-site',
   prefetch: {
     defaultStrategy: 'hover',

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "0.9.9",
+    "@astrojs/markdown-satteri": "0.3.2",
     "@astrojs/starlight": "0.41.1",
     "@catppuccin/starlight": "2.0.1",
     "@eslint-community/eslint-plugin-eslint-comments": "4.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@astrojs/check':
         specifier: 0.9.9
         version: 0.9.9(prettier@3.9.0)(typescript@6.0.3)
+      '@astrojs/markdown-satteri':
+        specifier: 0.3.2
+        version: 0.3.2
       '@astrojs/starlight':
         specifier: 0.41.1
         version: 0.41.1(@astrojs/markdown-remark@7.2.0)(astro@7.0.4(@astrojs/markdown-remark@7.2.0)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@24.13.0)(jiti@2.7.0)(rollup@4.62.2)(yaml@2.9.0))(typescript@6.0.3)
@@ -432,8 +435,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@capsizecss/unpack@4.0.1':
-    resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
+  '@capsizecss/unpack@4.0.0':
+    resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
 
   '@catppuccin/starlight@2.0.1':
@@ -4619,7 +4622,7 @@ snapshots:
   '@bruits/satteri-win32-x64-msvc@0.9.4':
     optional: true
 
-  '@capsizecss/unpack@4.0.1':
+  '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
 
@@ -5817,7 +5820,7 @@ snapshots:
       '@astrojs/internal-helpers': 0.10.0
       '@astrojs/markdown-satteri': 0.3.2
       '@astrojs/telemetry': 3.3.2
-      '@capsizecss/unpack': 4.0.1
+      '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.6.0
       '@oslojs/encoding': 1.1.0
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)

--- a/site/src/content/docs/rules/repository-shorthand.mdx
+++ b/site/src/content/docs/rules/repository-shorthand.mdx
@@ -85,5 +85,3 @@ The `object` form is generally recommended as that's what `npm publish` prefers.
 ## Further Reading
 
 - [npm: package.json > repository](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository)
-- [michaelfaith/eslint-plugin-package-json#223 🐛 Bug: prefer-repository-shorthand in conflict with npm publish requirements](https://github.com/michaelfaith/eslint-plugin-package-json/issues/223)
-- [npm/cli#7299 [DOCS] package.json#repository should clarify normalization steps and future plans.](https://github.com/npm/cli/issues/7299)


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This should improve site build time, using their new rust-based markdown processor.