### PR TITLE
chore: enable typescript-eslint rules

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -47,7 +47,6 @@ export default defineConfig(
     ],
     files: JS_TS_FILES,
     rules: {
-      '@typescript-eslint/no-shadow': 'error',
       // We prefer seeing :exit after all other AST selectors in rules
       'perfectionist/sort-objects': [
         'error',
@@ -137,6 +136,11 @@ export default defineConfig(
       },
     },
     rules: {
+      '@typescript-eslint/consistent-type-exports': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/explicit-module-boundary-types': 'error',
+      '@typescript-eslint/no-shadow': 'error',
+
       'n/no-missing-import': 'off',
     },
     settings: {

--- a/site/src/openGraph/getOpenGraphImageUrl.ts
+++ b/site/src/openGraph/getOpenGraphImageUrl.ts
@@ -6,7 +6,7 @@ const routes = await getStaticPaths({} as GetStaticPathsOptions);
 
 const paths = new Set(routes.map(({ params }) => params.path));
 
-export function getOpenGraphImageUrl(path: string) {
+export function getOpenGraphImageUrl(path: string): string {
   const normalizedPath = path.replace(/^\//, '').replace(/\/$/, '');
 
   const ogPath = `${normalizedPath}.png`;

--- a/src/createRule.ts
+++ b/src/createRule.ts
@@ -1,10 +1,10 @@
-import { AST as ESLintAST, Rule, SourceCode } from 'eslint';
+import type { AST as ESLintAST, Rule, SourceCode } from 'eslint';
 import type * as ESTree from 'estree';
 import type {
   FromSchema as InferJsonSchemaType,
   JSONSchema,
 } from 'json-schema-to-ts';
-import { AST, type RuleListener } from 'jsonc-eslint-parser';
+import type { AST, RuleListener } from 'jsonc-eslint-parser';
 
 import { isPackageJson } from './utils/predicates/index.ts';
 

--- a/src/rules/bin-name-casing.ts
+++ b/src/rules/bin-name-casing.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from 'change-case';
-import { AST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 

--- a/src/rules/no-empty-fields.ts
+++ b/src/rules/no-empty-fields.ts
@@ -5,7 +5,7 @@ import {
 import type * as ESTree from 'estree';
 import type { AST } from 'jsonc-eslint-parser';
 
-import { createRule, PackageJsonRuleContext } from '../createRule.ts';
+import { createRule, type PackageJsonRuleContext } from '../createRule.ts';
 
 const getDataAndMessageId = (
   node: AST.JSONArrayExpression | AST.JSONObjectExpression | AST.JSONProperty,

--- a/src/rules/scripts-name-casing.ts
+++ b/src/rules/scripts-name-casing.ts
@@ -1,5 +1,5 @@
 import { kebabCase } from 'change-case';
-import { AST } from 'jsonc-eslint-parser';
+import type { AST } from 'jsonc-eslint-parser';
 
 import { createRule } from '../createRule.ts';
 

--- a/src/tests/index.test.ts
+++ b/src/tests/index.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
-import { ESLint, Linter } from 'eslint';
+import { ESLint, type Linter } from 'eslint';
 import { describe, expect, it } from 'vitest';
 
 import plugin from '../index.ts';

--- a/src/types/estree.d.ts
+++ b/src/types/estree.d.ts
@@ -1,4 +1,4 @@
-import { JSONNode } from 'jsonc-eslint-parser';
+import type { JSONNode } from 'jsonc-eslint-parser';
 
 declare module 'estree' {
   interface NodeMap {

--- a/src/utils/createSimpleRequirePropertyRule.ts
+++ b/src/utils/createSimpleRequirePropertyRule.ts
@@ -1,6 +1,6 @@
 import type { AST } from 'jsonc-eslint-parser';
 
-import { createRule } from '../createRule.ts';
+import { createRule, type PackageJsonRuleModule } from '../createRule.ts';
 import { isJSONStringLiteral } from './predicates/index.ts';
 
 export interface CreateRequirePropertyRuleOptions {
@@ -37,7 +37,10 @@ export const createSimpleRequirePropertyRule = (
     ignorePrivateDefault = false,
     isRecommended,
   }: CreateRequirePropertyRuleOptions = {},
-) => {
+): {
+  rule: PackageJsonRuleModule;
+  ruleName: string;
+} => {
   const ruleName = `require-${propertyName}`;
   const rule = createRule({
     create(context) {

--- a/src/utils/createSimpleValidPropertyRule.ts
+++ b/src/utils/createSimpleValidPropertyRule.ts
@@ -1,7 +1,7 @@
 import type { AST } from 'jsonc-eslint-parser';
 import type { Result } from 'package-json-validator';
 
-import { createRule } from '../createRule.ts';
+import { createRule, type PackageJsonRuleModule } from '../createRule.ts';
 
 // TODO: move this type upstream to `package-json-validator`
 export type ValidationFunction = (value: unknown) => Result;
@@ -16,7 +16,10 @@ export const createSimpleValidPropertyRule = (
   propertyName: string,
   validationFunction: ValidationFunction,
   aliases: string[] = [],
-) => {
+): {
+  rule: PackageJsonRuleModule;
+  ruleName: string;
+} => {
   const ruleName = `valid-${propertyName}`;
 
   const propertyNames = [propertyName, ...aliases];

--- a/src/utils/findPropertyWithKeyValue.ts
+++ b/src/utils/findPropertyWithKeyValue.ts
@@ -9,7 +9,7 @@ export type JSONPropertyWithKeyAndValue<Value extends string> =
 export function findPropertyWithKeyValue<Value extends string>(
   properties: AST.JSONProperty[],
   value: Value,
-) {
+): JSONPropertyWithKeyAndValue<Value> | undefined {
   return properties.find(
     (property): property is JSONPropertyWithKeyAndValue<Value> =>
       property.key.type === 'JSONLiteral' && property.key.value === value,

--- a/src/utils/predicates/isPackageJson.ts
+++ b/src/utils/predicates/isPackageJson.ts
@@ -1,2 +1,2 @@
-export const isPackageJson = (filePath: string) =>
+export const isPackageJson = (filePath: string): boolean =>
   /(?:^|[/\\])package.json$/.test(filePath);


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change enables `explicit-module-boundary-types`, `consistent-type-exports`, and `consistent-type-imports`, and addresses existing violations
