### PR TITLE
chore: combine non-type-aware configs and type-aware configs

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -42,13 +42,33 @@ export default defineConfig(
       eslintPlugin.configs.recommended,
       n.configs['flat/recommended'],
       regexp.configs['flat/recommended'],
+      tseslint.configs.strictTypeChecked,
+      tseslint.configs.stylisticTypeChecked,
       unicorn.configs.unopinionated,
     ],
     files: JS_TS_FILES,
+    languageOptions: {
+      parserOptions: {
+        projectService: {
+          allowDefaultProject: [
+            'astro.config.ts',
+            '.simple-git-hooks.js',
+            'knip.ts',
+          ],
+        },
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
     plugins: {
       perfectionist,
     },
     rules: {
+      '@typescript-eslint/consistent-type-exports': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/explicit-module-boundary-types': 'error',
+      '@typescript-eslint/no-shadow': 'error',
+      'n/no-missing-import': 'off',
+
       // Stylistic concerns that don't interfere with Prettier
       'logical-assignment-operators': [
         'error',
@@ -60,7 +80,6 @@ export default defineConfig(
       'operator-assignment': 'error',
 
       'perfectionist/sort-exports': 'error',
-      'perfectionist/sort-union-types': 'error',
 
       // Overly strict
       'unicorn/no-array-reverse': 'off',
@@ -71,6 +90,7 @@ export default defineConfig(
     },
     settings: {
       perfectionist: { partitionByComment: true, type: 'natural' },
+      vitest: { typecheck: true },
     },
   },
   {
@@ -104,36 +124,7 @@ export default defineConfig(
       'markdown/no-missing-label-refs': 'off',
     },
   },
-  {
-    extends: [
-      tseslint.configs.strictTypeChecked,
-      tseslint.configs.stylisticTypeChecked,
-    ],
-    files: JS_TS_FILES,
-    languageOptions: {
-      parserOptions: {
-        projectService: {
-          allowDefaultProject: [
-            'astro.config.ts',
-            '.simple-git-hooks.js',
-            'knip.ts',
-          ],
-        },
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
-    rules: {
-      '@typescript-eslint/consistent-type-exports': 'error',
-      '@typescript-eslint/consistent-type-imports': 'error',
-      '@typescript-eslint/explicit-module-boundary-types': 'error',
-      '@typescript-eslint/no-shadow': 'error',
-
-      'n/no-missing-import': 'off',
-    },
-    settings: {
-      vitest: { typecheck: true },
-    },
-  },
+  // Test-only rules
   {
     extends: [vitest.configs.recommended],
     files: ['**/*.test.*'],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change just merges the two different configs targeting js/ts files.  I'd previously broken out only the rules that needed type information into a separate config set up with type settings.  I've been questioning that distinction, at least within the context of our use case.
