### PR TITLE
fix: update @types/estree to 1.0.9 to fix published declaration incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@eslint/json": "2.0.0",
     "@eslint/markdown": "8.0.1",
     "@ianvs/prettier-plugin-sort-imports": "4.7.1",
-    "@types/estree": "1.0.8",
+    "@types/estree": "1.0.9",
     "@types/node": "24.13.0",
     "@types/semver": "7.7.1",
     "@typescript/native": "npm:typescript@7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 4.0.1
       eslint-fix-utils:
         specifier: ~0.4.3
-        version: 0.4.3(@types/estree@1.0.8)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
+        version: 0.4.3(@types/estree@1.0.9)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))
       eslint-json-compat-utils:
         specifier: ^0.2.3
         version: 0.2.3(@eslint/json@2.0.0)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(jsonc-eslint-parser@3.1.0)
@@ -73,8 +73,8 @@ importers:
         specifier: 4.7.1
         version: 4.7.1(prettier@3.9.0)(supports-color@7.2.0)
       '@types/estree':
-        specifier: 1.0.8
-        version: 1.0.8
+        specifier: 1.0.9
+        version: 1.0.9
       '@types/node':
         specifier: 24.13.0
         version: 24.13.0
@@ -1475,9 +1475,6 @@ packages:
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
-
-  '@types/estree@1.0.8':
-    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -5079,7 +5076,7 @@ snapshots:
 
   '@mdx-js/mdx@3.1.1(supports-color@7.2.0)':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.14
@@ -5371,7 +5368,7 @@ snapshots:
 
   '@rollup/pluginutils@5.4.0':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.5
 
@@ -5443,9 +5440,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.8
-
-  '@types/estree@1.0.8': {}
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
 
@@ -6298,11 +6293,11 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-fix-utils@0.4.3(@types/estree@1.0.8)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0)):
+  eslint-fix-utils@0.4.3(@types/estree@1.0.9)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0)):
     dependencies:
       eslint: 10.7.0(jiti@2.7.0)(supports-color@7.2.0)
     optionalDependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   eslint-json-compat-utils@0.2.3(@eslint/json@2.0.0)(eslint@10.7.0(jiti@2.7.0)(supports-color@7.2.0))(jsonc-eslint-parser@3.1.0):
     dependencies:
@@ -6445,7 +6440,7 @@ snapshots:
   eslint-scope@9.1.2:
     dependencies:
       '@types/esrecurse': 4.3.1
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esrecurse: 4.3.0
       estraverse: 5.3.0
 
@@ -6464,7 +6459,7 @@ snapshots:
       '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
       debug: 4.4.3(supports-color@7.2.0)
@@ -6508,7 +6503,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -6521,7 +6516,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -6539,7 +6534,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
@@ -6774,7 +6769,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3(supports-color@7.2.0):
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -6809,7 +6804,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6(supports-color@7.2.0):
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -7442,7 +7437,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -7453,7 +7448,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -7470,7 +7465,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -7506,7 +7501,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -7570,7 +7565,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -7951,7 +7946,7 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
@@ -7966,14 +7961,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -8032,7 +8027,7 @@ snapshots:
 
   rehype-recma@1.0.0(supports-color@7.2.0):
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3(supports-color@7.2.0)
     transitivePeerDependencies:


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #2033
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22) — I filed #2033 today and sent this alongside it since the change is a one-line dependency bump; happy to close and wait for triage if you'd prefer.
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Bumps the `@types/estree` devDependency pin from 1.0.8 to 1.0.9 so the bundled declarations are regenerated against the estree shapes that current `eslint` resolves in consumer projects.

As detailed in #2033, `tsdown` inlines a copy of the estree node types into `dist/createRule-*.d.mts` at build time. With the repo pinned to 1.0.8, the inlined `Property.key: Expression | PrivateIdentifier` no longer matches `@types/estree@1.0.9` (`Property.key: Expression`), which consumers resolve through `eslint`. Any consumer typechecking with `strict: true` and without `skipLibCheck` gets three TS2430 errors (`PackageAST`, `PackageJsonRuleContext`, `PackageJsonSourceCode` failing their `extends` clauses).

Verified locally:

- `pnpm typecheck` and `pnpm build` pass on this branch.
- The regenerated `dist/createRule-*.d.mts` now declares `Property.key: Expression`, matching 1.0.9 (the remaining `PrivateIdentifier` occurrences are `PropertyDefinition`/`MemberExpression`, which legitimately keep it).
- A downstream project that reproduces #2033 (strict, no `skipLibCheck`, `@types/estree@1.0.9` in tree) typechecks cleanly against the rebuilt `dist/`.

The lockfile was updated with `pnpm@11.15.0` (the pinned `packageManager`), so the diff is limited to the 1.0.8 → 1.0.9 swap.

Note this keeps the type-inlining approach, so the same class of breakage can recur if `@types/estree` changes shape again — the more durable option (referencing `@types/estree` as a dependency instead of inlining it) is sketched in #2033 if you'd rather go that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
