### PR TITLE
fix: don't bundle estree types

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,10 +118,14 @@
   },
   "peerDependencies": {
     "@eslint/json": ">=1.0.0",
+    "@types/estree": ">=1.0.0",
     "eslint": ">=9.0.0"
   },
   "peerDependenciesMeta": {
     "@eslint/json": {
+      "optional": true
+    },
+    "@types/estree": {
       "optional": true
     }
   },


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2033
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change externalizes `@types/estree` by setting it as an optional peer dependency
