### PR TITLE
fix(valid-dependencies): support pnpm's named registries

### DIFF
--- a/e2e/pnpm-lock.yaml
+++ b/e2e/pnpm-lock.yaml
@@ -354,6 +354,9 @@ packages:
     resolution: {integrity: sha512-pd5HlhSA4oymER74A8ODqcOHz3sQAQjmTysx1oiJrIMRtIWl9pqxX5L3aUqRb5CBFpXroA8j6fhJmaFKhVUuxQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -757,6 +760,8 @@ snapshots:
       semver: 7.8.5
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 7.0.2
+
+  package-manager-detector@1.8.0: {}
 
   path-exists@4.0.0: {}
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "eslint-json-compat-utils": "^0.2.3",
     "jsonc-eslint-parser": "^3.1.0",
     "package-json-validator": "^1.6.0",
-    "package-manager-detector": "^1.8.0",
     "semver": "^7.7.3",
     "sort-object-keys": "^2.0.0",
     "sort-package-json": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "eslint-fix-utils": "~0.4.3",
     "eslint-json-compat-utils": "^0.2.3",
     "jsonc-eslint-parser": "^3.1.0",
-    "package-json-validator": "^1.5.0",
+    "package-json-validator": "^1.6.0",
+    "package-manager-detector": "^1.8.0",
     "semver": "^7.7.3",
     "sort-object-keys": "^2.0.0",
     "sort-package-json": "^4.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0
       package-json-validator:
-        specifier: ^1.5.0
+        specifier: ^1.6.0
         version: 1.6.0
       semver:
         specifier: ^7.7.3

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -34,6 +34,8 @@ import {
   validateVersion,
   validateWorkspaces,
 } from 'package-json-validator';
+import { detect } from 'package-manager-detector';
+import semver from 'semver';
 
 import {
   createSimpleValidPropertyRule,
@@ -44,6 +46,21 @@ interface ValidPropertyOptions {
   aliases: string[];
   validator: ValidationFunction;
 }
+
+const packageManagerInfo = await detect();
+
+const packageManagerAwareValidateDependencies: ValidationFunction = (value) => {
+  // Allow for named registries if the user is using pnpm >= 11.1.0
+  // https://github.com/michaelfaith/eslint-plugin-package-json/issues/2057
+  if (
+    packageManagerInfo?.name === 'pnpm' &&
+    (!packageManagerInfo.version ||
+      semver.gte(packageManagerInfo.version, '11.1.0'))
+  ) {
+    return validateDependencies(value, { allowNamedRegistries: true });
+  }
+  return validateDependencies(value);
+};
 
 // List of all properties we want to create valid- rules for,
 // in the format [propertyName, validationFunction | validPropertyOptions]
@@ -62,8 +79,8 @@ const properties = [
   ['contributors', validateContributors],
   ['cpu', validateCpu],
   ['description', validateDescription],
-  ['dependencies', validateDependencies],
-  ['devDependencies', validateDependencies],
+  ['dependencies', packageManagerAwareValidateDependencies],
+  ['devDependencies', packageManagerAwareValidateDependencies],
   ['devEngines', validateDevEngines],
   ['directories', validateDirectories],
   ['engines', validateEngines],

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -53,7 +53,6 @@ const packageManagerAwareValidateDependencies: ValidationFunction = (value) => {
     process.env.npm_config_user_agent?.match(userAgentRegex);
 
   // Allow for named registries if the user is using pnpm >= 11.1.0.
-  // The detector returns the current package manager name from the npm user agent.
   // https://github.com/michaelfaith/eslint-plugin-package-json/issues/2057
   if (userAgentMatch?.[1] === 'pnpm') {
     const version = userAgentMatch[2];

--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -34,7 +34,6 @@ import {
   validateVersion,
   validateWorkspaces,
 } from 'package-json-validator';
-import { detect } from 'package-manager-detector';
 import semver from 'semver';
 
 import {
@@ -47,18 +46,23 @@ interface ValidPropertyOptions {
   validator: ValidationFunction;
 }
 
-const packageManagerInfo = await detect();
+const userAgentRegex = /^(.+?)\/(\S+)?/;
 
 const packageManagerAwareValidateDependencies: ValidationFunction = (value) => {
-  // Allow for named registries if the user is using pnpm >= 11.1.0
+  const userAgentMatch =
+    process.env.npm_config_user_agent?.match(userAgentRegex);
+
+  // Allow for named registries if the user is using pnpm >= 11.1.0.
+  // The detector returns the current package manager name from the npm user agent.
   // https://github.com/michaelfaith/eslint-plugin-package-json/issues/2057
-  if (
-    packageManagerInfo?.name === 'pnpm' &&
-    (!packageManagerInfo.version ||
-      semver.gte(packageManagerInfo.version, '11.1.0'))
-  ) {
-    return validateDependencies(value, { allowNamedRegistries: true });
+  if (userAgentMatch?.[1] === 'pnpm') {
+    const version = userAgentMatch[2];
+
+    if (!version || semver.gte(version, '11.1.0')) {
+      return validateDependencies(value, { allowNamedRegistries: true });
+    }
   }
+
   return validateDependencies(value);
 };
 

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -1,37 +1,32 @@
 import type { RuleTester } from 'eslint';
-import { describe, vi } from 'vitest';
+import { afterAll, describe } from 'vitest';
 
+import { rules } from '../../rules/valid-properties.ts';
 import { ruleTester } from './ruleTester.ts';
-
-const mockDetect = vi.fn();
-vi.mock('package-manager-detector', () => ({
-  detect: mockDetect,
-}));
 
 interface TestEnvironment {
   description: string;
-  beforeAll: (() => void) | (() => Promise<void>);
-  additionalValidTests?: (RuleTester.ValidTestCase | string)[];
+  before: () => void;
+  additionalValidTests?: RuleTester.ValidTestCase[];
   additionalInvalidTests?: RuleTester.InvalidTestCase[];
 }
 
 const testEnvironments: TestEnvironment[] = [
   {
     description: 'with pnpm 11.1.0',
-    beforeAll: () => {
-      mockDetect.mockResolvedValue({
-        name: 'pnpm',
-        agent: 'pnpm',
-        version: '11.1.0',
-      });
+    before: () => {
+      process.env.npm_config_user_agent =
+        'pnpm/11.1.0 npm/? node/v24.11.0 linux x64';
     },
     additionalValidTests: [
-      `{
+      {
+        code: `{
   "dependencies": {
     "cst-records": "record-label:foo@^1.2.3"
   }
 }
 `,
+      },
     ],
     additionalInvalidTests: [
       {
@@ -67,70 +62,106 @@ const testEnvironments: TestEnvironment[] = [
   },
   {
     description: 'with pnpm 11.0.0',
-    beforeAll: () => {
-      mockDetect.mockResolvedValue({
-        name: 'pnpm',
-        agent: 'pnpm',
-        version: '11.0.0',
-      });
+    before: () => {
+      process.env.npm_config_user_agent =
+        'pnpm/11.0.0 npm/? node/v24.11.0 linux x64';
     },
   },
   {
     description: 'with pnpm 10.0.0',
-    beforeAll: () => {
-      mockDetect.mockResolvedValue({
-        name: 'pnpm',
-        agent: 'pnpm',
-        version: '10.0.0',
-      });
+    before: () => {
+      process.env.npm_config_user_agent =
+        'pnpm/10.0.0 npm/? node/v24.11.0 linux x64';
     },
   },
   {
     description: 'with pnpm, but no version',
-    beforeAll: () => {
-      mockDetect.mockResolvedValue({
-        name: 'pnpm',
-        agent: 'pnpm',
-      });
+    before: () => {
+      process.env.npm_config_user_agent = 'pnpm/ node/v24.11.0 linux x64';
     },
+    additionalValidTests: [
+      {
+        code: `{
+  "dependencies": {
+    "cst-records": "record-label:foo@^1.2.3"
+  }
+}
+`,
+      },
+    ],
+    additionalInvalidTests: [
+      {
+        code: `{
+  "dependencies": {
+    "empty-custom-protocol": "work:",
+    "bad-custom-protocol": "work:git+foo://github.com/npm/cli.git"
+  }
+}
+`,
+        errors: [
+          {
+            column: 30,
+            data: {
+              error:
+                'invalid version spec for dependency `empty-custom-protocol`: Unsupported URL Type "work:": work:',
+            },
+            line: 3,
+            messageId: 'validationError',
+          },
+          {
+            column: 28,
+            data: {
+              error:
+                'invalid custom protocol arg for dependency `bad-custom-protocol`: Unsupported URL Type "git+foo:": git+foo://github.com/npm/cli.git',
+            },
+            line: 4,
+            messageId: 'validationError',
+          },
+        ],
+      },
+    ],
   },
   {
     description: 'with npm',
-    beforeAll: () => {
-      mockDetect.mockResolvedValue({
-        name: 'npm',
-        agent: 'npm',
-        version: '11.12.0',
-      });
+    before: () => {
+      process.env.npm_config_user_agent = 'npm/11.12.0 node/v24.11.0 linux x64';
     },
   },
   {
     description: 'with yarn',
-    beforeAll: () => {
-      mockDetect.mockResolvedValue({
-        name: 'yarn',
-        agent: 'yarn',
-        version: '4.18.0',
-      });
+    before: () => {
+      process.env.npm_config_user_agent =
+        'yarn/4.18.0 npm/? node/v24.11.0 linux x64';
+    },
+  },
+  {
+    description: 'with no unknown package manager',
+    before: () => {
+      process.env.npm_config_user_agent =
+        'unknown/1.0.0 npm/? node/v24.11.0 linux x64';
     },
   },
   {
     description: 'with no package manager detected',
-    beforeAll: () => {
-      mockDetect.mockResolvedValue(null);
+    before: () => {
+      process.env.npm_config_user_agent = undefined;
     },
   },
 ];
 
+const previousUserAgent = process.env.npm_config_user_agent;
+
+afterAll(() => {
+  process.env.npm_config_user_agent = previousUserAgent;
+});
+
 describe.each(testEnvironments)(
   '$description',
-  async ({ beforeAll, additionalValidTests, additionalInvalidTests }) => {
-    await beforeAll();
-
-    const { rules } = await import('../../rules/valid-properties.ts');
+  ({ before, additionalValidTests, additionalInvalidTests }) => {
     ruleTester.run('valid-dependencies', rules['valid-dependencies'], {
       invalid: [
         {
+          before,
           code: `{
 	"dependencies": null
 }
@@ -147,6 +178,7 @@ describe.each(testEnvironments)(
           ],
         },
         {
+          before,
           code: `{
 	"dependencies": 123
 }
@@ -162,6 +194,7 @@ describe.each(testEnvironments)(
           ],
         },
         {
+          before,
           code: `{
 	"dependencies": "./script.js"
 }
@@ -177,6 +210,7 @@ describe.each(testEnvironments)(
           ],
         },
         {
+          before,
           code: `{
 	"dependencies": []
 }
@@ -192,6 +226,7 @@ describe.each(testEnvironments)(
           ],
         },
         {
+          before,
           code: `{
 	"dependencies": {
     "david": "bowie",
@@ -231,11 +266,16 @@ describe.each(testEnvironments)(
             },
           ],
         },
-        ...(additionalInvalidTests ?? []),
+        ...(additionalInvalidTests?.map((test) => ({ before, ...test })) ?? []),
       ],
       valid: [
-        '{}',
-        `{
+        {
+          before,
+          code: '{}',
+        },
+        {
+          before,
+          code: `{
   "dependencies": {
     "silver-mt-zion": "^1.2.3",
     "nin": "file:./nin",
@@ -250,11 +290,13 @@ describe.each(testEnvironments)(
     "jessica-moss": "beta"
   }
 }`,
-        `{ "dependencies": {} }`,
-        ...(additionalValidTests ?? []),
+        },
+        {
+          before,
+          code: `{ "dependencies": {} }`,
+        },
+        ...(additionalValidTests?.map((test) => ({ before, ...test })) ?? []),
       ],
     });
-
-    vi.resetModules();
   },
 );

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -1,113 +1,241 @@
-import { rules } from '../../rules/valid-properties.ts';
+import type { RuleTester } from 'eslint';
+import { describe, vi } from 'vitest';
+
 import { ruleTester } from './ruleTester.ts';
 
-ruleTester.run('valid-dependencies', rules['valid-dependencies'], {
-  invalid: [
-    {
-      code: `{
+const mockDetect = vi.fn();
+vi.mock('package-manager-detector', () => ({
+  detect: mockDetect,
+}));
+
+interface TestEnvironment {
+  description: string;
+  beforeAll: (() => void) | (() => Promise<void>);
+  additionalValidTests?: (RuleTester.ValidTestCase | string)[];
+  additionalInvalidTests?: RuleTester.InvalidTestCase[];
+}
+
+const testEnvironments: TestEnvironment[] = [
+  {
+    description: 'with pnpm 11.1.0',
+    beforeAll: () => {
+      mockDetect.mockResolvedValue({
+        name: 'pnpm',
+        agent: 'pnpm',
+        version: '11.1.0',
+      });
+    },
+    additionalValidTests: [
+      `{
+  "dependencies": {
+    "cst-records": "record-label:foo@^1.2.3"
+  }
+}
+`,
+    ],
+    additionalInvalidTests: [
+      {
+        code: `{
+  "dependencies": {
+    "empty-custom-protocol": "work:",
+    "bad-custom-protocol": "work:git+foo://github.com/npm/cli.git"
+  }
+}
+`,
+        errors: [
+          {
+            column: 30,
+            data: {
+              error:
+                'invalid version spec for dependency `empty-custom-protocol`: Unsupported URL Type "work:": work:',
+            },
+            line: 3,
+            messageId: 'validationError',
+          },
+          {
+            column: 28,
+            data: {
+              error:
+                'invalid custom protocol arg for dependency `bad-custom-protocol`: Unsupported URL Type "git+foo:": git+foo://github.com/npm/cli.git',
+            },
+            line: 4,
+            messageId: 'validationError',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    description: 'with pnpm 11.0.0',
+    beforeAll: () => {
+      mockDetect.mockResolvedValue({
+        name: 'pnpm',
+        agent: 'pnpm',
+        version: '11.0.0',
+      });
+    },
+  },
+  {
+    description: 'with pnpm 10.0.0',
+    beforeAll: () => {
+      mockDetect.mockResolvedValue({
+        name: 'pnpm',
+        agent: 'pnpm',
+        version: '10.0.0',
+      });
+    },
+  },
+  {
+    description: 'with pnpm, but no version',
+    beforeAll: () => {
+      mockDetect.mockResolvedValue({
+        name: 'pnpm',
+        agent: 'pnpm',
+      });
+    },
+  },
+  {
+    description: 'with npm',
+    beforeAll: () => {
+      mockDetect.mockResolvedValue({
+        name: 'npm',
+        agent: 'npm',
+        version: '11.12.0',
+      });
+    },
+  },
+  {
+    description: 'with yarn',
+    beforeAll: () => {
+      mockDetect.mockResolvedValue({
+        name: 'yarn',
+        agent: 'yarn',
+        version: '4.18.0',
+      });
+    },
+  },
+  {
+    description: 'with no package manager detected',
+    beforeAll: () => {
+      mockDetect.mockResolvedValue(null);
+    },
+  },
+];
+
+describe.each(testEnvironments)(
+  '$description',
+  async ({ beforeAll, additionalValidTests, additionalInvalidTests }) => {
+    await beforeAll();
+
+    const { rules } = await import('../../rules/valid-properties.ts');
+    ruleTester.run('valid-dependencies', rules['valid-dependencies'], {
+      invalid: [
+        {
+          code: `{
 	"dependencies": null
 }
 `,
-      errors: [
-        {
-          data: {
-            error:
-              'the value is `null`, but should be a record of dependencies',
-          },
-          line: 2,
-          messageId: 'validationError',
+          errors: [
+            {
+              data: {
+                error:
+                  'the value is `null`, but should be a record of dependencies',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
         },
-      ],
-    },
-    {
-      code: `{
+        {
+          code: `{
 	"dependencies": 123
 }
 `,
-      errors: [
-        {
-          data: {
-            error: 'the type should be `object`, not `number`',
-          },
-          line: 2,
-          messageId: 'validationError',
+          errors: [
+            {
+              data: {
+                error: 'the type should be `object`, not `number`',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
         },
-      ],
-    },
-    {
-      code: `{
+        {
+          code: `{
 	"dependencies": "./script.js"
 }
 `,
-      errors: [
-        {
-          data: {
-            error: 'the type should be `object`, not `string`',
-          },
-          line: 2,
-          messageId: 'validationError',
+          errors: [
+            {
+              data: {
+                error: 'the type should be `object`, not `string`',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
         },
-      ],
-    },
-    {
-      code: `{
+        {
+          code: `{
 	"dependencies": []
 }
 `,
-      errors: [
-        {
-          data: {
-            error: 'the type should be `object`, not `array`',
-          },
-          line: 2,
-          messageId: 'validationError',
+          errors: [
+            {
+              data: {
+                error: 'the type should be `object`, not `array`',
+              },
+              line: 2,
+              messageId: 'validationError',
+            },
+          ],
         },
-      ],
-    },
-    {
-      code: `{
+        {
+          code: `{
 	"dependencies": {
-        "david": "bowie",
-        "trent": 123,
-        "the-fragile": null,
-        "pink-floyd": {},
-        "childish-gambino": "workspace"
-    }
+    "david": "bowie",
+    "trent": 123,
+    "the-fragile": null,
+    "pink-floyd": {},
+    "childish-gambino": "workspace"
+  }
 }
 `,
-      errors: [
-        {
-          column: 18,
-          data: {
-            error: 'dependency version for `trent` should be a string: 123',
-          },
-          line: 4,
-          messageId: 'validationError',
+          errors: [
+            {
+              column: 14,
+              data: {
+                error: 'dependency version for `trent` should be a string: 123',
+              },
+              line: 4,
+              messageId: 'validationError',
+            },
+            {
+              column: 20,
+              data: {
+                error:
+                  'dependency version for `the-fragile` should be a string: null',
+              },
+              line: 5,
+              messageId: 'validationError',
+            },
+            {
+              column: 19,
+              data: {
+                error:
+                  'dependency version for `pink-floyd` should be a string: [object Object]',
+              },
+              line: 6,
+              messageId: 'validationError',
+            },
+          ],
         },
-        {
-          column: 24,
-          data: {
-            error:
-              'dependency version for `the-fragile` should be a string: null',
-          },
-          line: 5,
-          messageId: 'validationError',
-        },
-        {
-          column: 23,
-          data: {
-            error:
-              'dependency version for `pink-floyd` should be a string: [object Object]',
-          },
-          line: 6,
-          messageId: 'validationError',
-        },
+        ...(additionalInvalidTests ?? []),
       ],
-    },
-  ],
-  valid: [
-    '{}',
-    `{
+      valid: [
+        '{}',
+        `{
   "dependencies": {
     "silver-mt-zion": "^1.2.3",
     "nin": "file:./nin",
@@ -122,6 +250,11 @@ ruleTester.run('valid-dependencies', rules['valid-dependencies'], {
     "jessica-moss": "beta"
   }
 }`,
-    `{ "dependencies": {} }`,
-  ],
-});
+        `{ "dependencies": {} }`,
+        ...(additionalValidTests ?? []),
+      ],
+    });
+
+    vi.resetModules();
+  },
+);


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2057
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds support for pnpm's [named registry](https://pnpm.io/settings#namedregistries) feature.  If you're using pnpm >=11.1.0, the rule will allow for custom protocols.  I was originally going to go with `package-manager-detector`, since its check is more reliable than just the user agent, but they removed the sync api a while back, and only provide an async version of `detect` now.

> [!NOTE]
> We do _not_ check that the custom protocol matches an entry in the project's `pnpm-workspace.yaml`.
