### PR TITLE
fix(scripts-name-casing): support "hidden" scripts and `pnpm:devPreinstall`

### DIFF
--- a/src/rules/scripts-name-casing.ts
+++ b/src/rules/scripts-name-casing.ts
@@ -4,7 +4,10 @@ import type { AST } from 'jsonc-eslint-parser';
 import { createRule } from '../createRule.ts';
 
 // See https://docs.npmjs.com/cli/v11/using-npm/scripts
-const BUILT_IN_SCRIPTS_IN_CAMEL_CASE = new Set(['prepublishOnly']);
+const BUILT_IN_SCRIPTS_IN_CAMEL_CASE = new Set([
+  'prepublishOnly',
+  'pnpm:devPreinstall',
+]);
 
 export const rule = createRule({
   create(context) {
@@ -20,11 +23,12 @@ export const rule = createRule({
               continue;
             }
 
-            const kebabCaseKey = key
+            // Don't include a leading '.'
+            const kebabCaseKey = (key.startsWith('.') ? key.slice(1) : key)
               .split(':')
               .map((segment) => kebabCase(segment))
               .join(':');
-            if (kebabCaseKey !== key) {
+            if (kebabCaseKey !== (key.startsWith('.') ? key.slice(1) : key)) {
               context.report({
                 data: {
                   property: key,
@@ -39,7 +43,11 @@ export const rule = createRule({
                     fix: (fixer) => {
                       return fixer.replaceText(
                         keyNode,
-                        JSON.stringify(kebabCaseKey),
+                        JSON.stringify(
+                          key.startsWith('.')
+                            ? `.${kebabCaseKey}`
+                            : kebabCaseKey,
+                        ),
                       );
                     },
                     messageId: 'convertToKebabCase',

--- a/src/tests/rules/scripts-name-casing.test.ts
+++ b/src/tests/rules/scripts-name-casing.test.ts
@@ -5,13 +5,16 @@ ruleTester.run('scripts-name-casing', rule, {
   invalid: [
     {
       code: `{
-                "scripts": {
-                    "silverMtZion": "silver-mt-zion.js",
-                    "NIN": "./nin.js"
-                }
-            }`,
+  "scripts": {
+    "silverMtZion": "silver-mt-zion.js",
+    "NIN": "./nin.js",
+    ".GodspeedYouBlackEmperor": "./gybe.js",
+    ".alt.j": "./alt-j.js"
+  }
+}`,
       errors: [
         {
+          column: 5,
           data: {
             property: 'silverMtZion',
           },
@@ -24,15 +27,18 @@ ruleTester.run('scripts-name-casing', rule, {
               },
               messageId: 'convertToKebabCase',
               output: `{
-                "scripts": {
-                    "silver-mt-zion": "silver-mt-zion.js",
-                    "NIN": "./nin.js"
-                }
-            }`,
+  "scripts": {
+    "silver-mt-zion": "silver-mt-zion.js",
+    "NIN": "./nin.js",
+    ".GodspeedYouBlackEmperor": "./gybe.js",
+    ".alt.j": "./alt-j.js"
+  }
+}`,
             },
           ],
         },
         {
+          column: 5,
           data: {
             property: 'NIN',
           },
@@ -45,11 +51,61 @@ ruleTester.run('scripts-name-casing', rule, {
               },
               messageId: 'convertToKebabCase',
               output: `{
-                "scripts": {
-                    "silverMtZion": "silver-mt-zion.js",
-                    "nin": "./nin.js"
-                }
-            }`,
+  "scripts": {
+    "silverMtZion": "silver-mt-zion.js",
+    "nin": "./nin.js",
+    ".GodspeedYouBlackEmperor": "./gybe.js",
+    ".alt.j": "./alt-j.js"
+  }
+}`,
+            },
+          ],
+        },
+        {
+          column: 5,
+          data: {
+            property: '.GodspeedYouBlackEmperor',
+          },
+          line: 5,
+          messageId: 'invalidCase',
+          suggestions: [
+            {
+              data: {
+                property: '.GodspeedYouBlackEmperor',
+              },
+              messageId: 'convertToKebabCase',
+              output: `{
+  "scripts": {
+    "silverMtZion": "silver-mt-zion.js",
+    "NIN": "./nin.js",
+    ".godspeed-you-black-emperor": "./gybe.js",
+    ".alt.j": "./alt-j.js"
+  }
+}`,
+            },
+          ],
+        },
+        {
+          column: 5,
+          data: {
+            property: '.alt.j',
+          },
+          line: 6,
+          messageId: 'invalidCase',
+          suggestions: [
+            {
+              data: {
+                property: '.alt.j',
+              },
+              messageId: 'convertToKebabCase',
+              output: `{
+  "scripts": {
+    "silverMtZion": "silver-mt-zion.js",
+    "NIN": "./nin.js",
+    ".GodspeedYouBlackEmperor": "./gybe.js",
+    ".alt-j": "./alt-j.js"
+  }
+}`,
             },
           ],
         },
@@ -64,5 +120,7 @@ ruleTester.run('scripts-name-casing', rule, {
     `{ "scripts": { "silver-mt-zion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
     `{ "scripts": { "silver-mt-zion": "silver-mt-zion.js", "godspeed-you:black-emperor": "./gybe.js", "n:i:n": "./nin.js" } }`,
     `{ "scripts": { "prepublishOnly": "npm run build" } }`,
+    `{ "scripts": { "pnpm:devPreinstall": "node preinstall.mjs" } }`,
+    `{ "scripts": { ".silver-mt-zion": "silver-mt-zion.js", "nin": "./nin.js" } }`,
   ],
 });


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #2047
- [x] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds support for both the [built-in](https://pnpm.io/scripts#pnpmdevpreinstall) `pnpm:devPreinstall` and pnpm's ["hidden" scripts](https://pnpm.io/scripts#hidden-scripts).

For hidden scripts, we're still validating that the hidden script is kebab-case, we're just ignoring the leading `.`, when performing validation and making fix suggestions.
