### PR TITLE
chore(deps): update dependency @altano/repository-tools to v2.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@altano/repository-tools": "^2.0.1",
+    "@altano/repository-tools": "^2.0.5",
     "@types/estree": "^1.0.0",
     "change-case": "^5.4.4",
     "detect-indent": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
   .:
     dependencies:
       '@altano/repository-tools':
-        specifier: ^2.0.1
+        specifier: ^2.0.5
         version: 2.0.5
       '@types/estree':
         specifier: ^1.0.0


### PR DESCRIPTION
## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Updates `@altano/repository-tools` from `^2.0.1` to `^2.0.5`, the release containing the fix for inherited Git environment variables causing incorrect repository-root discovery. This prevents `valid-repository-directory` false positives when eslint-plugin-package-json runs from Git hooks in linked worktrees.

References altano/npm-packages#299.

✨

Generated with Codex.

_Verified by a human (me) before posting._