### PR TITLE
fix(valid-dependencies): improve package manager detection

### DIFF
--- a/src/rules/valid-properties.ts
+++ b/src/rules/valid-properties.ts
@@ -40,22 +40,20 @@ import {
   createSimpleValidPropertyRule,
   type ValidationFunction,
 } from '../utils/createSimpleValidPropertyRule.js';
+import { detectPackageManager } from '../utils/packageManager/detectPackageManager.ts';
 
 interface ValidPropertyOptions {
   aliases: string[];
   validator: ValidationFunction;
 }
 
-const userAgentRegex = /^(.+?)\/(\S+)?/;
-
 const packageManagerAwareValidateDependencies: ValidationFunction = (value) => {
-  const userAgentMatch =
-    process.env.npm_config_user_agent?.match(userAgentRegex);
+  const result = detectPackageManager();
 
   // Allow for named registries if the user is using pnpm >= 11.1.0.
   // https://github.com/michaelfaith/eslint-plugin-package-json/issues/2057
-  if (userAgentMatch?.[1] === 'pnpm') {
-    const version = userAgentMatch[2];
+  if (result?.name === 'pnpm') {
+    const version = result.version;
 
     if (!version || semver.gte(version, '11.1.0')) {
       return validateDependencies(value, { allowNamedRegistries: true });

--- a/src/tests/rules/valid-dependencies.test.ts
+++ b/src/tests/rules/valid-dependencies.test.ts
@@ -1,8 +1,13 @@
 import type { RuleTester } from 'eslint';
-import { afterAll, describe } from 'vitest';
+import { describe, vi } from 'vitest';
 
 import { rules } from '../../rules/valid-properties.ts';
+import { detectPackageManager } from '../../utils/packageManager/detectPackageManager.ts';
 import { ruleTester } from './ruleTester.ts';
+
+vi.mock('../../utils/packageManager/detectPackageManager.ts', () => ({
+  detectPackageManager: vi.fn(),
+}));
 
 interface TestEnvironment {
   description: string;
@@ -15,8 +20,10 @@ const testEnvironments: TestEnvironment[] = [
   {
     description: 'with pnpm 11.1.0',
     before: () => {
-      process.env.npm_config_user_agent =
-        'pnpm/11.1.0 npm/? node/v24.11.0 linux x64';
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'pnpm',
+        version: '11.1.0',
+      });
     },
     additionalValidTests: [
       {
@@ -63,21 +70,27 @@ const testEnvironments: TestEnvironment[] = [
   {
     description: 'with pnpm 11.0.0',
     before: () => {
-      process.env.npm_config_user_agent =
-        'pnpm/11.0.0 npm/? node/v24.11.0 linux x64';
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'pnpm',
+        version: '11.0.0',
+      });
     },
   },
   {
     description: 'with pnpm 10.0.0',
     before: () => {
-      process.env.npm_config_user_agent =
-        'pnpm/10.0.0 npm/? node/v24.11.0 linux x64';
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'pnpm',
+        version: '10.0.0',
+      });
     },
   },
   {
     description: 'with pnpm, but no version',
     before: () => {
-      process.env.npm_config_user_agent = 'pnpm/ node/v24.11.0 linux x64';
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'pnpm',
+      });
     },
     additionalValidTests: [
       {
@@ -124,36 +137,28 @@ const testEnvironments: TestEnvironment[] = [
   {
     description: 'with npm',
     before: () => {
-      process.env.npm_config_user_agent = 'npm/11.12.0 node/v24.11.0 linux x64';
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'npm',
+        version: '11.12.0',
+      });
     },
   },
   {
     description: 'with yarn',
     before: () => {
-      process.env.npm_config_user_agent =
-        'yarn/4.18.0 npm/? node/v24.11.0 linux x64';
-    },
-  },
-  {
-    description: 'with no unknown package manager',
-    before: () => {
-      process.env.npm_config_user_agent =
-        'unknown/1.0.0 npm/? node/v24.11.0 linux x64';
+      vi.mocked(detectPackageManager).mockReturnValue({
+        name: 'yarn',
+        version: '4.18.0',
+      });
     },
   },
   {
     description: 'with no package manager detected',
     before: () => {
-      process.env.npm_config_user_agent = undefined;
+      vi.mocked(detectPackageManager).mockReturnValue(null);
     },
   },
 ];
-
-const previousUserAgent = process.env.npm_config_user_agent;
-
-afterAll(() => {
-  process.env.npm_config_user_agent = previousUserAgent;
-});
 
 describe.each(testEnvironments)(
   '$description',

--- a/src/utils/packageManager/constants.ts
+++ b/src/utils/packageManager/constants.ts
@@ -1,6 +1,3 @@
-export type AgentName =
-  'npm' | 'yarn' | 'pnpm' | 'bun' | 'deno' | 'nub' | 'aube';
-
 export interface DetectResult {
   /**
    * Agent name without the specifier.
@@ -15,7 +12,7 @@ export interface DetectResult {
   version?: string;
 }
 
-export const AGENTS: AgentName[] = [
+export const AGENTS = [
   'npm',
   'yarn',
   'pnpm',
@@ -23,7 +20,8 @@ export const AGENTS: AgentName[] = [
   'deno',
   'nub',
   'aube',
-];
+] as const;
+export type AgentName = (typeof AGENTS)[number];
 
 // the order here matters, more specific one comes first
 export const LOCK_FILES: Record<string, AgentName> = {

--- a/src/utils/packageManager/constants.ts
+++ b/src/utils/packageManager/constants.ts
@@ -1,0 +1,41 @@
+export type AgentName =
+  'npm' | 'yarn' | 'pnpm' | 'bun' | 'deno' | 'nub' | 'aube';
+
+export interface DetectResult {
+  /**
+   * Agent name without the specifier.
+   *
+   * Can be `npm`, `yarn`, `pnpm`, `bun`, `deno`, `nub`, or `aube`.
+   */
+  name: AgentName;
+
+  /**
+   * Specific version of the agent, read from `packageManager` field in package.json.
+   */
+  version?: string;
+}
+
+export const AGENTS: AgentName[] = [
+  'npm',
+  'yarn',
+  'pnpm',
+  'bun',
+  'deno',
+  'nub',
+  'aube',
+];
+
+// the order here matters, more specific one comes first
+export const LOCK_FILES: Record<string, AgentName> = {
+  'aube-lock.yaml': 'aube',
+  'aube-workspace.yaml': 'aube',
+  'bun.lock': 'bun',
+  'bun.lockb': 'bun',
+  'deno.lock': 'deno',
+  'nub.lock': 'nub',
+  'pnpm-lock.yaml': 'pnpm',
+  'pnpm-workspace.yaml': 'pnpm',
+  'yarn.lock': 'yarn',
+  'package-lock.json': 'npm',
+  'npm-shrinkwrap.json': 'npm',
+};

--- a/src/utils/packageManager/constants.ts
+++ b/src/utils/packageManager/constants.ts
@@ -1,3 +1,14 @@
+export const AGENTS = [
+  'npm',
+  'yarn',
+  'pnpm',
+  'bun',
+  'deno',
+  'nub',
+  'aube',
+] as const;
+export type AgentName = (typeof AGENTS)[number];
+
 export interface DetectResult {
   /**
    * Agent name without the specifier.
@@ -11,17 +22,6 @@ export interface DetectResult {
    */
   version?: string;
 }
-
-export const AGENTS = [
-  'npm',
-  'yarn',
-  'pnpm',
-  'bun',
-  'deno',
-  'nub',
-  'aube',
-] as const;
-export type AgentName = (typeof AGENTS)[number];
 
 // the order here matters, more specific one comes first
 export const LOCK_FILES: Record<string, AgentName> = {

--- a/src/utils/packageManager/detectPackageManager.test.ts
+++ b/src/utils/packageManager/detectPackageManager.test.ts
@@ -1,0 +1,293 @@
+import path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const existsSyncMock = vi.fn();
+const readFileSyncMock = vi.fn();
+const cwdMock = vi.fn();
+const env: Record<string, string | undefined> = {};
+
+vi.mock('node:fs', () => ({
+  default: {
+    existsSync: existsSyncMock,
+    readFileSync: readFileSyncMock,
+  },
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+const processMock = {
+  cwd: cwdMock,
+  env,
+};
+
+vi.mock('node:process', () => ({
+  default: processMock,
+  ...processMock,
+}));
+
+const importDetectPackageManager = async () =>
+  await import('./detectPackageManager.ts');
+
+describe('detectPackageManager', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    cwdMock.mockReset();
+    existsSyncMock.mockReset();
+    readFileSyncMock.mockReset();
+    for (const key of Object.keys(env)) {
+      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+      delete env[key];
+    }
+    env.npm_config_user_agent = undefined;
+    existsSyncMock.mockReturnValue(false);
+    readFileSyncMock.mockImplementation(() => {
+      throw new Error('Unexpected read');
+    });
+  });
+
+  it('detects a package manager from a lockfile in the current directory', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const lockfilePath = path.join(cwd, 'pnpm-lock.yaml');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === lockfilePath,
+    );
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'pnpm' });
+  });
+
+  it('prefers rush.json detection over regular lockfile detection', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const rushPath = path.join(cwd, 'rush.json');
+    const lockfilePath = path.join(cwd, 'pnpm-lock.yaml');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === rushPath || filepath === lockfilePath,
+    );
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'pnpm' });
+  });
+
+  it('detects packageManager field values from package.json', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const packageJsonPath = path.join(cwd, 'package.json');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === packageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === packageJsonPath) {
+        return JSON.stringify({ packageManager: 'pnpm@9.1.0' });
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'pnpm', version: '9.1.0' });
+  });
+
+  it('detects devEngines.packageManager values when packageManager is absent', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const packageJsonPath = path.join(cwd, 'package.json');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === packageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === packageJsonPath) {
+        return JSON.stringify({
+          devEngines: {
+            packageManager: {
+              name: 'bun',
+              version: '1.2.3',
+            },
+          },
+        });
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'bun', version: '1.2.3' });
+  });
+
+  it('detects packageManager field values from package.json with sha hash version', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const packageJsonPath = path.join(cwd, 'package.json');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === packageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === packageJsonPath) {
+        return JSON.stringify({
+          packageManager:
+            'pnpm@11.1.0+sha512.5383cc12567a95f1d668fbe762dfe0075c595b4bfff433be478dbbe24e05251a8e8c3eb992a986667c1d53b6c3a9c85b8398c35a960587fbd9fa3a0915406728',
+        });
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'pnpm', version: '11.1.0' });
+  });
+
+  it('detects packageManager field values from package.json with bad version', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const packageJsonPath = path.join(cwd, 'package.json');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === packageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === packageJsonPath) {
+        return JSON.stringify({
+          packageManager: 'pnpm@sha',
+        });
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'pnpm', version: 'sha' });
+  });
+
+  it('looks upward for package.json values in parent directories', async () => {
+    const cwd = path.resolve('/workspace/project/packages/app');
+    const currentPackageJsonPath = path.join(cwd, 'package.json');
+    const parentPackageJsonPath = path.join(
+      path.dirname(cwd),
+      '..',
+      'package.json',
+    );
+    const resolvedParentPackageJsonPath = path.resolve(parentPackageJsonPath);
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) =>
+        filepath === currentPackageJsonPath ||
+        filepath === resolvedParentPackageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === resolvedParentPackageJsonPath) {
+        return JSON.stringify({ packageManager: 'yarn@4.5.0' });
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'yarn', version: '4.5.0' });
+  });
+
+  it('uses npm_config_user_agent when no file-based detection matches', async () => {
+    const cwd = path.resolve('/workspace/project');
+
+    cwdMock.mockReturnValue(cwd);
+    env.npm_config_user_agent = 'pnpm/9.1.0';
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toEqual({ name: 'pnpm', version: '9.1.0' });
+  });
+
+  it('ignores unsupported user agents and returns null', async () => {
+    const cwd = path.resolve('/workspace/project');
+
+    cwdMock.mockReturnValue(cwd);
+    env.npm_config_user_agent = 'unknown/1.0.0';
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toBeNull();
+  });
+
+  it('returns null when package.json exists but does not include packageManager field', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const packageJsonPath = path.join(cwd, 'package.json');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === packageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === packageJsonPath) {
+        return JSON.stringify({ name: 'my-package' });
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toBeNull();
+  });
+
+  it('returns null when package.json exists but cannot be parsed', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const packageJsonPath = path.join(cwd, 'package.json');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === packageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === packageJsonPath) {
+        throw new Error('Invalid JSON');
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    expect(detectPackageManager()).toBeNull();
+  });
+
+  it('caches the detected package manager after the first lookup', async () => {
+    const cwd = path.resolve('/workspace/project');
+    const packageJsonPath = path.join(cwd, 'package.json');
+
+    cwdMock.mockReturnValue(cwd);
+    existsSyncMock.mockImplementation(
+      (filepath: string) => filepath === packageJsonPath,
+    );
+    readFileSyncMock.mockImplementation((filepath: string) => {
+      if (filepath === packageJsonPath) {
+        return JSON.stringify({ packageManager: 'npm@10.2.0' });
+      }
+
+      throw new Error(`Unexpected file: ${filepath}`);
+    });
+
+    const { detectPackageManager } = await importDetectPackageManager();
+
+    const firstResult = detectPackageManager();
+    const secondResult = detectPackageManager();
+
+    expect(firstResult).toEqual({ name: 'npm', version: '10.2.0' });
+    expect(secondResult).toEqual(firstResult);
+    expect(readFileSyncMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/packageManager/detectPackageManager.ts
+++ b/src/utils/packageManager/detectPackageManager.ts
@@ -1,0 +1,149 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+import {
+  AGENTS,
+  LOCK_FILES,
+  type AgentName,
+  type DetectResult,
+} from './constants.ts';
+
+let packageManagerCache: DetectResult | undefined;
+
+const userAgentRegex = /^(.+?)\/(\S+)?/;
+
+function getPackageManagerFromUserAgent(): DetectResult | null {
+  const userAgentMatch =
+    process.env.npm_config_user_agent?.match(userAgentRegex);
+
+  if (userAgentMatch) {
+    const name = userAgentMatch[1] as AgentName;
+    const version = userAgentMatch[2];
+
+    if (AGENTS.includes(name)) {
+      return { name, version };
+    }
+  }
+
+  return null;
+}
+
+function setPackageManagerCache(result: DetectResult) {
+  packageManagerCache = result;
+  return packageManagerCache;
+}
+
+function* lookup(cwd: string = process.cwd()): Generator<string> {
+  let directory = path.resolve(cwd);
+  const { root } = path.parse(directory);
+
+  while (directory && directory !== root) {
+    yield directory;
+
+    directory = path.dirname(directory);
+  }
+}
+
+function parsePackageJson(filepath: string): DetectResult | null {
+  if (!filepath || !fs.existsSync(filepath)) {
+    return null;
+  }
+
+  return handlePackageManager(filepath);
+}
+
+/**
+ * Detects the package manager used in the project.
+ * @returns The detected package manager or `null` if not found.
+ */
+export function detectPackageManager(): DetectResult | null {
+  if (packageManagerCache) {
+    return packageManagerCache;
+  }
+
+  const cwd = process.cwd();
+  const strategies = ['lockfile', 'packageManager-field', 'user-agent'];
+
+  for (const directory of lookup(cwd)) {
+    for (const strategy of strategies) {
+      switch (strategy) {
+        case 'lockfile': {
+          // Rush monorepos wrap pnpm with `rush-pnpm`; detect them before
+          // falling back to the regular lock file lookup.
+          if (fs.existsSync(path.join(directory, 'rush.json'))) {
+            return setPackageManagerCache({ name: 'pnpm' });
+          }
+          // Look up for lock files
+          // eslint-disable-next-line unicorn/prefer-object-iterable-methods
+          for (const lock of Object.keys(LOCK_FILES)) {
+            if (fs.existsSync(path.join(directory, lock))) {
+              const name = LOCK_FILES[lock];
+              const result = parsePackageJson(
+                path.join(directory, 'package.json'),
+              );
+              return setPackageManagerCache(result ?? { name });
+            }
+          }
+          break;
+        }
+        case 'packageManager-field': {
+          // Look up for package.json
+          const result = parsePackageJson(path.join(directory, 'package.json'));
+          if (result) {
+            return setPackageManagerCache(result);
+          }
+          break;
+        }
+        case 'user-agent': {
+          const result = getPackageManagerFromUserAgent();
+          if (result) {
+            return setPackageManagerCache(result);
+          }
+          break;
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
+interface PackageJson {
+  packageManager?: string;
+  devEngines?: { packageManager?: { name?: string; version?: string } };
+}
+
+function getNameAndVersion(pkg: PackageJson) {
+  const normalizeVersion = (version: string | undefined) =>
+    version?.match(/\d+(?:\.\d+){0,2}/)?.[0] ?? version;
+  if (typeof pkg.packageManager === 'string') {
+    const [name, version] = pkg.packageManager.replace(/^\^/, '').split('@', 2);
+    return { name, version: normalizeVersion(version) };
+  }
+  if (typeof pkg.devEngines?.packageManager?.name === 'string') {
+    return {
+      name: pkg.devEngines.packageManager.name,
+      version: normalizeVersion(pkg.devEngines.packageManager.version),
+    };
+  }
+  return;
+}
+
+function handlePackageManager(filepath: string): DetectResult | null {
+  // read `packageManager` field in package.json using an optional custom parser
+  try {
+    const content = fs.readFileSync(filepath, 'utf8');
+    const pkg = JSON.parse(content) as PackageJson;
+
+    const nameAndVer = getNameAndVersion(pkg);
+    if (nameAndVer) {
+      const name = nameAndVer.name as AgentName;
+      const version = nameAndVer.version;
+      return { name, version };
+    }
+  } catch {
+    /* empty */
+  }
+  return null;
+}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change improves the package manager detection logic that `valid-dependencies` uses to detect what package manager the repo is using.  Previously it just used useragent, which, in my mind, isn't sufficient.  This effectively forks `package-manager-detector` and moves it to a sync api.  Additionally I added the same user agent logic as a fallback.  We now check for lock files first, then the packageManager field in a `package.json`, and lastly the user agent.
