### PR TITLE
ci: add site build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,13 @@ jobs:
           name: ci-build-assets
           path: dist/
 
+  build_site:
+    name: Build Site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: $/.github/actions/setup
+      - run: pnpm site:build
+
   dedupe_check:
     name: Dedupe Check
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to eslint-plugin-package-json! 🗂
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [ ] Addresses an existing open issue: fixes #000
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/michaelfaith/eslint-plugin-package-json/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [ ] Steps in [CONTRIBUTING.md](https://github.com/michaelfaith/eslint-plugin-package-json/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This change adds the site build as a ci step, so I can enable it as a required ci step.  The Cloudflare preview only runs on PRs authored by team members...  Once https://github.com/michaelfaith/eslint-plugin-package-json/issues/2052 is implemented, we should be able to remove this.
